### PR TITLE
Copilot/cambiar formulario agregar monto

### DIFF
--- a/src/features/deudas/components/DebtForm.js
+++ b/src/features/deudas/components/DebtForm.js
@@ -23,6 +23,8 @@ export class DebtForm extends HTMLElement {
         this._analyticsStep = 'form';
         this._analyticsCompleted = false;
         this._analyticsStartedFor = null;
+        // Amount section mode: idle (list), creating, editing
+        this._amountMode = 'idle';
         // Inline editing state: null = no inline open, 'new' = adding, number = editing existing
         this._inlineEditIdx = null;
         this._inlineEditRef = null; // direct reference to the monto object being edited
@@ -161,10 +163,15 @@ export class DebtForm extends HTMLElement {
                             className: 'invalid-feedback mt-2 d-none'
                         }),
                         el('div', {
+                            attrs: { id: 'monto-form-title' },
+                            className: 'fw-semibold mt-3 mb-2 d-none'
+                        }),
+                        el('div', {
                             attrs: { id: 'add-monto-form-container' },
                             className: 'mt-3 d-none'
                         }),
                         el('div', {
+                            attrs: { id: 'add-monto-btn-row' },
                             className: 'd-flex justify-content-end mt-3',
                             children: [
                                 el('app-button', { attrs: { id: 'add-monto', variant: 'secondary' }, text: 'Agregar monto' })
@@ -256,6 +263,7 @@ export class DebtForm extends HTMLElement {
         }
         this._analyticsStep = 'add_installment';
         updateFlowStep(this._analyticsFlow || this._getFlowName(), this._analyticsStep);
+        this._amountMode = 'creating';
         this._inlineEditIdx = 'new';
         this._inlineEditRef = null;
         this.renderMontosList();
@@ -272,6 +280,7 @@ export class DebtForm extends HTMLElement {
         }
         this._analyticsStep = 'edit_installment';
         updateFlowStep(this._analyticsFlow || this._getFlowName(), this._analyticsStep);
+        this._amountMode = 'editing';
         this._inlineEditIdx = idx;
         this._inlineEditRef = monto; // stable reference — survives sort/splice
         this.renderMontosList();
@@ -281,17 +290,16 @@ export class DebtForm extends HTMLElement {
     // Cancel the currently open inline form without saving changes.
     _cancelInline() {
         // montos array was never modified during inline editing, just clear the UI state
+        this._amountMode = 'idle';
         this._inlineEditIdx = null;
         this._inlineEditRef = null;
         this.renderMontosList();
     }
 
-    // Focus the first input/select in the active inline row.
+    // Focus the first input/select in the active monto form container.
     _focusFirstInlineInput() {
         setTimeout(() => {
-            const selector = this._inlineEditIdx === 'new'
-                ? '#add-monto-form-container input, #add-monto-form-container select'
-                : '.inline-edit-row input, .inline-edit-row select';
+            const selector = '#add-monto-form-container input, #add-monto-form-container select';
             const input = this.querySelector(selector);
             if (input) input.focus();
         }, 0);
@@ -303,6 +311,7 @@ export class DebtForm extends HTMLElement {
         if (inline) {
             montoFormEl.inline = true;
         }
+        montoFormEl.compactErrors = true;
         if (monto) {
             // Set before appending so connectedCallback renders with the correct values.
             montoFormEl.monto = {
@@ -326,6 +335,7 @@ export class DebtForm extends HTMLElement {
                 const editIdx = this.montos.indexOf(this._inlineEditRef);
                 if (editIdx >= 0) this.montos[editIdx] = nuevoMonto;
             }
+            this._amountMode = 'idle';
             this._inlineEditIdx = null;
             this._inlineEditRef = null;
             this.renderMontosList();
@@ -336,23 +346,32 @@ export class DebtForm extends HTMLElement {
         return montoFormEl;
     }
 
-    // Build the inline editing row using monto-form (delegates validation to AppForm).
-    _buildInlineRow(monto) {
-        const montoFormEl = this._buildMontoForm(monto);
-        const tr = el('tr', { className: 'inline-edit-row' });
-        tr.appendChild(el('td', { attrs: { colspan: '4' }, children: [montoFormEl] }));
-        return tr;
-    }
-
     _renderInlineAddForm() {
         const container = this.querySelector('#add-monto-form-container');
+        const title = this.querySelector('#monto-form-title');
+        const tableWrapper = this.querySelector('#montos-table-wrapper');
+        const addMontoBtnRow = this.querySelector('#add-monto-btn-row');
         if (!container) return;
         container.innerHTML = '';
-        if (this._inlineEditIdx === 'new') {
+        if (this._amountMode === 'creating') {
             container.classList.remove('d-none');
+            title?.classList.remove('d-none');
+            if (title) title.textContent = 'Nuevo monto';
+            tableWrapper?.classList.add('d-none');
+            addMontoBtnRow?.classList.add('d-none');
             container.appendChild(this._buildMontoForm(null, { inline: true }));
+        } else if (this._amountMode === 'editing' && this._inlineEditRef) {
+            container.classList.remove('d-none');
+            title?.classList.remove('d-none');
+            if (title) title.textContent = 'Editar monto';
+            tableWrapper?.classList.add('d-none');
+            addMontoBtnRow?.classList.add('d-none');
+            container.appendChild(this._buildMontoForm(this._inlineEditRef, { inline: true }));
         } else {
+            title?.classList.add('d-none');
             container.classList.add('d-none');
+            tableWrapper?.classList.remove('d-none');
+            addMontoBtnRow?.classList.remove('d-none');
         }
     }
 
@@ -377,11 +396,6 @@ export class DebtForm extends HTMLElement {
             this.clearFormError();
         }
         this.montos.forEach((monto, idx) => {
-            if (this._inlineEditRef !== null && monto === this._inlineEditRef) {
-                // Render inline edit row for this existing monto
-                this.montosTbody.appendChild(this._buildInlineRow(monto));
-                return;
-            }
             const tr = el('tr');
             const cells = [
                 { text: monto.monto },
@@ -446,6 +460,7 @@ export class DebtForm extends HTMLElement {
         this.editing = true;
         this.deudaId = deuda.id;
         this.montos = deuda.montos.map(m => ({ ...m }));
+        this._amountMode = 'idle';
         this._inlineEditIdx = null;
         this._inlineEditRef = null;
         this.renderMontosList();
@@ -473,6 +488,7 @@ export class DebtForm extends HTMLElement {
         this.editing = false;
         this.deudaId = null;
         this.montos = [];
+        this._amountMode = 'idle';
         this._inlineEditIdx = null;
         this._inlineEditRef = null;
         const form = this.querySelector('app-form');

--- a/src/features/deudas/components/DebtForm.js
+++ b/src/features/deudas/components/DebtForm.js
@@ -289,7 +289,9 @@ export class DebtForm extends HTMLElement {
     // Focus the first input/select in the active inline row.
     _focusFirstInlineInput() {
         setTimeout(() => {
-            const input = this.querySelector('.inline-edit-row input, .inline-edit-row select, #add-monto-form-container input, #add-monto-form-container select');
+            const editInput = this.querySelector('.inline-edit-row input, .inline-edit-row select');
+            const addInput = this.querySelector('#add-monto-form-container input, #add-monto-form-container select');
+            const input = editInput || addInput;
             if (input) input.focus();
         }, 0);
     }

--- a/src/features/deudas/components/DebtForm.js
+++ b/src/features/deudas/components/DebtForm.js
@@ -161,6 +161,10 @@ export class DebtForm extends HTMLElement {
                             className: 'invalid-feedback mt-2 d-none'
                         }),
                         el('div', {
+                            attrs: { id: 'add-monto-form-container' },
+                            className: 'mt-3 d-none'
+                        }),
+                        el('div', {
                             className: 'd-flex justify-content-end mt-3',
                             children: [
                                 el('app-button', { attrs: { id: 'add-monto', variant: 'secondary' }, text: 'Agregar monto' })
@@ -285,14 +289,17 @@ export class DebtForm extends HTMLElement {
     // Focus the first input/select in the active inline row.
     _focusFirstInlineInput() {
         setTimeout(() => {
-            const input = this.montosTbody && this.montosTbody.querySelector('.inline-edit-row input, .inline-edit-row select');
+            const input = this.querySelector('.inline-edit-row input, .inline-edit-row select, #add-monto-form-container input, #add-monto-form-container select');
             if (input) input.focus();
         }, 0);
     }
 
-    // Build the inline editing row using monto-form (delegates validation to AppForm).
-    _buildInlineRow(monto) {
+    // Build the inline monto form (delegates validation to AppForm).
+    _buildMontoForm(monto, { inline = false } = {}) {
         const montoFormEl = document.createElement('monto-form');
+        if (inline) {
+            montoFormEl.inline = true;
+        }
         if (monto) {
             // Set before appending so connectedCallback renders with the correct values.
             montoFormEl.monto = {
@@ -323,9 +330,27 @@ export class DebtForm extends HTMLElement {
         montoFormEl.addEventListener('monto:cancel', () => {
             this._cancelInline();
         });
+        return montoFormEl;
+    }
+
+    // Build the inline editing row using monto-form (delegates validation to AppForm).
+    _buildInlineRow(monto) {
+        const montoFormEl = this._buildMontoForm(monto);
         const tr = el('tr', { className: 'inline-edit-row' });
         tr.appendChild(el('td', { attrs: { colspan: '4' }, children: [montoFormEl] }));
         return tr;
+    }
+
+    _renderInlineAddForm() {
+        const container = this.querySelector('#add-monto-form-container');
+        if (!container) return;
+        container.innerHTML = '';
+        if (this._inlineEditIdx === 'new') {
+            container.classList.remove('d-none');
+            container.appendChild(this._buildMontoForm(null, { inline: true }));
+        } else {
+            container.classList.add('d-none');
+        }
     }
 
     // Duplicate a monto in memory: copies monto/moneda/vencimiento, forces pagado=false.
@@ -344,6 +369,7 @@ export class DebtForm extends HTMLElement {
         // Ordenar montos por fecha de vencimiento ascendente
         this.montos.sort((a, b) => new Date(a.vencimiento) - new Date(b.vencimiento));
         this.montosTbody.innerHTML = '';
+        this._renderInlineAddForm();
         if (this.hasMontosAdded()) {
             this.clearFormError();
         }
@@ -411,10 +437,6 @@ export class DebtForm extends HTMLElement {
             cells.forEach(cellOpts => tr.appendChild(el('td', cellOpts)));
             this.montosTbody.appendChild(tr);
         });
-        // If adding a new monto, append the inline add row at the bottom
-        if (this._inlineEditIdx === 'new') {
-            this.montosTbody.appendChild(this._buildInlineRow(null));
-        }
     }
 
     load(deuda) {

--- a/src/features/deudas/components/DebtForm.js
+++ b/src/features/deudas/components/DebtForm.js
@@ -1,10 +1,10 @@
 import { DeudaModel } from '../DeudaModel.js';
 import { el } from '../../../shared/utils/dom.js';
-import monedas from '../../../shared/config/monedas.js';
 import '../../../shared/components/AppButton.js';
 import '../../../shared/components/AppCheckbox.js';
 import '../../../shared/components/AppInput.js';
 import '../../../shared/components/AppForm.js';
+import '../../montos/components/MontoForm.js';
 import {
     trackFlowStart,
     trackFlowComplete,
@@ -12,10 +12,6 @@ import {
     trackFlowAbandoned,
     updateFlowStep
 } from '../../../shared/observability/index.js';
-
-const INLINE_MONTO_ERROR = 'Ingresá un monto válido mayor que 0.';
-const INLINE_MONEDA_ERROR = 'Seleccioná una moneda.';
-const INLINE_VENC_ERROR = 'Ingresá la fecha de vencimiento.';
 
 export class DebtForm extends HTMLElement {
     constructor() {
@@ -278,63 +274,6 @@ export class DebtForm extends HTMLElement {
         this._focusFirstInlineInput();
     }
 
-    // Save the currently open inline form.
-    _saveInline() {
-        const row = this.montosTbody && this.montosTbody.querySelector('.inline-edit-row');
-        if (!row) return;
-        const montoInput = row.querySelector('input[name="monto"]');
-        const monedaSelect = row.querySelector('select[name="moneda"]');
-        const vencimientoInput = row.querySelector('input[name="vencimiento"]');
-        const _showError = (input, msg) => {
-            input.classList.add('is-invalid');
-            input.setAttribute('aria-invalid', 'true');
-            const fb = input.nextElementSibling;
-            if (fb && fb.classList.contains('invalid-feedback')) fb.textContent = msg;
-        };
-        const _clearError = (input) => {
-            input.classList.remove('is-invalid');
-            input.removeAttribute('aria-invalid');
-        };
-        let hasError = false;
-        if (!montoInput.checkValidity()) {
-            _showError(montoInput, INLINE_MONTO_ERROR);
-            hasError = true;
-        } else {
-            _clearError(montoInput);
-        }
-        if (!monedaSelect.checkValidity()) {
-            _showError(monedaSelect, INLINE_MONEDA_ERROR);
-            hasError = true;
-        } else {
-            _clearError(monedaSelect);
-        }
-        if (!vencimientoInput.checkValidity()) {
-            _showError(vencimientoInput, INLINE_VENC_ERROR);
-            hasError = true;
-        } else {
-            _clearError(vencimientoInput);
-        }
-        if (hasError) return;
-        const existing = this._inlineEditRef; // null when adding new
-        const nuevoMonto = {
-            monto: parseFloat(montoInput.value),
-            moneda: monedaSelect.value,
-            vencimiento: vencimientoInput.value,
-            pagado: existing ? (existing.pagado ?? false) : false,
-            ...(existing && existing.id !== undefined ? { id: existing.id } : {})
-        };
-        if (this._inlineEditIdx === 'new') {
-            this.montos.push(nuevoMonto);
-        } else {
-            // Use indexOf on the stored reference to survive sort/splice shifts
-            const editIdx = this.montos.indexOf(this._inlineEditRef);
-            if (editIdx >= 0) this.montos[editIdx] = nuevoMonto;
-        }
-        this._inlineEditIdx = null;
-        this._inlineEditRef = null;
-        this.renderMontosList();
-    }
-
     // Cancel the currently open inline form without saving changes.
     _cancelInline() {
         // montos array was never modified during inline editing, just clear the UI state
@@ -351,60 +290,41 @@ export class DebtForm extends HTMLElement {
         }, 0);
     }
 
-    // Build the inline editing row (used for both add and edit).
+    // Build the inline editing row using monto-form (delegates validation to AppForm).
     _buildInlineRow(monto) {
-        const montoInput = el('input', {
-            attrs: {
-                type: 'number', name: 'monto', min: '0', required: '',
-                class: 'form-control form-control-sm',
-                ...(monto ? { value: String(monto.monto) } : {})
+        const montoFormEl = document.createElement('monto-form');
+        if (monto) {
+            // Set before appending so connectedCallback renders with the correct values.
+            montoFormEl.monto = {
+                monto: monto.monto,
+                moneda: monto.moneda,
+                vencimiento: monto.vencimiento
+            };
+        }
+        montoFormEl.addEventListener('monto:save', (e) => {
+            const existing = this._inlineEditRef;
+            const nuevoMonto = {
+                monto: parseFloat(e.detail.monto),
+                moneda: e.detail.moneda,
+                vencimiento: e.detail.vencimiento,
+                pagado: existing ? (existing.pagado ?? false) : false,
+                ...(existing && existing.id !== undefined ? { id: existing.id } : {})
+            };
+            if (this._inlineEditIdx === 'new') {
+                this.montos.push(nuevoMonto);
+            } else {
+                const editIdx = this.montos.indexOf(this._inlineEditRef);
+                if (editIdx >= 0) this.montos[editIdx] = nuevoMonto;
             }
+            this._inlineEditIdx = null;
+            this._inlineEditRef = null;
+            this.renderMontosList();
         });
-        const montoFeedback = el('div', { className: 'invalid-feedback', text: INLINE_MONTO_ERROR });
-        montoInput.addEventListener('input', () => {
-            montoInput.classList.remove('is-invalid');
-            montoInput.removeAttribute('aria-invalid');
-        });
-        const monedaSelect = el('select', {
-            attrs: { name: 'moneda', required: '', class: 'form-select form-select-sm' }
-        });
-        monedas.forEach(m => {
-            const opt = el('option', { text: m, attrs: { value: m } });
-            if (monto && monto.moneda === m) opt.selected = true;
-            monedaSelect.appendChild(opt);
-        });
-        const monedaFeedback = el('div', { className: 'invalid-feedback', text: INLINE_MONEDA_ERROR });
-        monedaSelect.addEventListener('change', () => {
-            monedaSelect.classList.remove('is-invalid');
-            monedaSelect.removeAttribute('aria-invalid');
-        });
-        const vencInput = el('input', {
-            attrs: {
-                type: 'date', name: 'vencimiento', required: '',
-                class: 'form-control form-control-sm',
-                ...(monto ? { value: monto.vencimiento } : {})
-            }
-        });
-        const vencFeedback = el('div', { className: 'invalid-feedback', text: INLINE_VENC_ERROR });
-        vencInput.addEventListener('input', () => {
-            vencInput.classList.remove('is-invalid');
-            vencInput.removeAttribute('aria-invalid');
-        });
-        const saveBtn = el('app-button', {
-            className: 'save-inline', text: '✓',
-            attrs: { title: 'Guardar', 'aria-label': 'Guardar monto' },
-            on: { click: () => this._saveInline() }
-        });
-        const cancelBtn = el('app-button', {
-            className: 'cancel-inline', text: '✕',
-            attrs: { variant: 'secondary', title: 'Cancelar', 'aria-label': 'Cancelar' },
-            on: { click: () => this._cancelInline() }
+        montoFormEl.addEventListener('monto:cancel', () => {
+            this._cancelInline();
         });
         const tr = el('tr', { className: 'inline-edit-row' });
-        tr.appendChild(el('td', { children: [montoInput, montoFeedback] }));
-        tr.appendChild(el('td', { children: [monedaSelect, monedaFeedback] }));
-        tr.appendChild(el('td', { children: [vencInput, vencFeedback] }));
-        tr.appendChild(el('td', { children: [el('div', { className: 'd-flex gap-1 align-items-center', children: [saveBtn, cancelBtn] })] }));
+        tr.appendChild(el('td', { attrs: { colspan: '4' }, children: [montoFormEl] }));
         return tr;
     }
 

--- a/src/features/deudas/components/DebtForm.js
+++ b/src/features/deudas/components/DebtForm.js
@@ -289,9 +289,10 @@ export class DebtForm extends HTMLElement {
     // Focus the first input/select in the active inline row.
     _focusFirstInlineInput() {
         setTimeout(() => {
-            const editInput = this.querySelector('.inline-edit-row input, .inline-edit-row select');
-            const addInput = this.querySelector('#add-monto-form-container input, #add-monto-form-container select');
-            const input = editInput || addInput;
+            const selector = this._inlineEditIdx === 'new'
+                ? '#add-monto-form-container input, #add-monto-form-container select'
+                : '.inline-edit-row input, .inline-edit-row select';
+            const input = this.querySelector(selector);
             if (input) input.focus();
         }, 0);
     }

--- a/src/features/deudas/components/DebtForm.js
+++ b/src/features/deudas/components/DebtForm.js
@@ -13,6 +13,10 @@ import {
     updateFlowStep
 } from '../../../shared/observability/index.js';
 
+const INLINE_MONTO_ERROR = 'Ingresá un monto válido mayor que 0.';
+const INLINE_MONEDA_ERROR = 'Seleccioná una moneda.';
+const INLINE_VENC_ERROR = 'Ingresá la fecha de vencimiento.';
+
 export class DebtForm extends HTMLElement {
     constructor() {
         super();
@@ -293,19 +297,19 @@ export class DebtForm extends HTMLElement {
         };
         let hasError = false;
         if (!montoInput.checkValidity()) {
-            _showError(montoInput, 'Ingresá un monto válido mayor que 0.');
+            _showError(montoInput, INLINE_MONTO_ERROR);
             hasError = true;
         } else {
             _clearError(montoInput);
         }
         if (!monedaSelect.checkValidity()) {
-            _showError(monedaSelect, 'Seleccioná una moneda.');
+            _showError(monedaSelect, INLINE_MONEDA_ERROR);
             hasError = true;
         } else {
             _clearError(monedaSelect);
         }
         if (!vencimientoInput.checkValidity()) {
-            _showError(vencimientoInput, 'Ingresá la fecha de vencimiento.');
+            _showError(vencimientoInput, INLINE_VENC_ERROR);
             hasError = true;
         } else {
             _clearError(vencimientoInput);
@@ -356,7 +360,7 @@ export class DebtForm extends HTMLElement {
                 ...(monto ? { value: String(monto.monto) } : {})
             }
         });
-        const montoFeedback = el('div', { className: 'invalid-feedback', text: 'Ingresá un monto válido mayor que 0.' });
+        const montoFeedback = el('div', { className: 'invalid-feedback', text: INLINE_MONTO_ERROR });
         montoInput.addEventListener('input', () => {
             montoInput.classList.remove('is-invalid');
             montoInput.removeAttribute('aria-invalid');
@@ -369,7 +373,7 @@ export class DebtForm extends HTMLElement {
             if (monto && monto.moneda === m) opt.selected = true;
             monedaSelect.appendChild(opt);
         });
-        const monedaFeedback = el('div', { className: 'invalid-feedback', text: 'Seleccioná una moneda.' });
+        const monedaFeedback = el('div', { className: 'invalid-feedback', text: INLINE_MONEDA_ERROR });
         monedaSelect.addEventListener('change', () => {
             monedaSelect.classList.remove('is-invalid');
             monedaSelect.removeAttribute('aria-invalid');
@@ -381,7 +385,7 @@ export class DebtForm extends HTMLElement {
                 ...(monto ? { value: monto.vencimiento } : {})
             }
         });
-        const vencFeedback = el('div', { className: 'invalid-feedback', text: 'Ingresá la fecha de vencimiento.' });
+        const vencFeedback = el('div', { className: 'invalid-feedback', text: INLINE_VENC_ERROR });
         vencInput.addEventListener('input', () => {
             vencInput.classList.remove('is-invalid');
             vencInput.removeAttribute('aria-invalid');

--- a/src/features/deudas/components/DebtForm.js
+++ b/src/features/deudas/components/DebtForm.js
@@ -281,10 +281,36 @@ export class DebtForm extends HTMLElement {
         const montoInput = row.querySelector('input[name="monto"]');
         const monedaSelect = row.querySelector('select[name="moneda"]');
         const vencimientoInput = row.querySelector('input[name="vencimiento"]');
-        // Use native HTML validation; stay in edit mode if invalid
-        if (!montoInput.reportValidity() || !monedaSelect.reportValidity() || !vencimientoInput.reportValidity()) {
-            return;
+        const _showError = (input, msg) => {
+            input.classList.add('is-invalid');
+            input.setAttribute('aria-invalid', 'true');
+            const fb = input.nextElementSibling;
+            if (fb && fb.classList.contains('invalid-feedback')) fb.textContent = msg;
+        };
+        const _clearError = (input) => {
+            input.classList.remove('is-invalid');
+            input.removeAttribute('aria-invalid');
+        };
+        let hasError = false;
+        if (!montoInput.checkValidity()) {
+            _showError(montoInput, 'Ingresá un monto válido mayor que 0.');
+            hasError = true;
+        } else {
+            _clearError(montoInput);
         }
+        if (!monedaSelect.checkValidity()) {
+            _showError(monedaSelect, 'Seleccioná una moneda.');
+            hasError = true;
+        } else {
+            _clearError(monedaSelect);
+        }
+        if (!vencimientoInput.checkValidity()) {
+            _showError(vencimientoInput, 'Ingresá la fecha de vencimiento.');
+            hasError = true;
+        } else {
+            _clearError(vencimientoInput);
+        }
+        if (hasError) return;
         const existing = this._inlineEditRef; // null when adding new
         const nuevoMonto = {
             monto: parseFloat(montoInput.value),
@@ -330,6 +356,11 @@ export class DebtForm extends HTMLElement {
                 ...(monto ? { value: String(monto.monto) } : {})
             }
         });
+        const montoFeedback = el('div', { className: 'invalid-feedback', text: 'Ingresá un monto válido mayor que 0.' });
+        montoInput.addEventListener('input', () => {
+            montoInput.classList.remove('is-invalid');
+            montoInput.removeAttribute('aria-invalid');
+        });
         const monedaSelect = el('select', {
             attrs: { name: 'moneda', required: '', class: 'form-select form-select-sm' }
         });
@@ -338,12 +369,22 @@ export class DebtForm extends HTMLElement {
             if (monto && monto.moneda === m) opt.selected = true;
             monedaSelect.appendChild(opt);
         });
+        const monedaFeedback = el('div', { className: 'invalid-feedback', text: 'Seleccioná una moneda.' });
+        monedaSelect.addEventListener('change', () => {
+            monedaSelect.classList.remove('is-invalid');
+            monedaSelect.removeAttribute('aria-invalid');
+        });
         const vencInput = el('input', {
             attrs: {
                 type: 'date', name: 'vencimiento', required: '',
                 class: 'form-control form-control-sm',
                 ...(monto ? { value: monto.vencimiento } : {})
             }
+        });
+        const vencFeedback = el('div', { className: 'invalid-feedback', text: 'Ingresá la fecha de vencimiento.' });
+        vencInput.addEventListener('input', () => {
+            vencInput.classList.remove('is-invalid');
+            vencInput.removeAttribute('aria-invalid');
         });
         const saveBtn = el('app-button', {
             className: 'save-inline', text: '✓',
@@ -356,9 +397,9 @@ export class DebtForm extends HTMLElement {
             on: { click: () => this._cancelInline() }
         });
         const tr = el('tr', { className: 'inline-edit-row' });
-        tr.appendChild(el('td', { children: [montoInput] }));
-        tr.appendChild(el('td', { children: [monedaSelect] }));
-        tr.appendChild(el('td', { children: [vencInput] }));
+        tr.appendChild(el('td', { children: [montoInput, montoFeedback] }));
+        tr.appendChild(el('td', { children: [monedaSelect, monedaFeedback] }));
+        tr.appendChild(el('td', { children: [vencInput, vencFeedback] }));
         tr.appendChild(el('td', { children: [el('div', { className: 'd-flex gap-1 align-items-center', children: [saveBtn, cancelBtn] })] }));
         return tr;
     }

--- a/src/features/deudas/components/DebtModal.js
+++ b/src/features/deudas/components/DebtModal.js
@@ -64,14 +64,14 @@ export class DebtModal extends HTMLElement {
 
                 const cancelBtn = document.createElement('button');
                 cancelBtn.type = 'button';
-                cancelBtn.className = 'btn btn-primary btn-sm';
+                cancelBtn.className = 'btn btn-primary';
                 cancelBtn.setAttribute('aria-label', 'Cancelar');
                 cancelBtn.textContent = 'Cancelar';
                 cancelBtn.addEventListener('click', () => appForm && appForm.triggerCancel());
 
                 const saveBtn = document.createElement('button');
                 saveBtn.type = 'button';
-                saveBtn.className = 'btn btn-success btn-sm';
+                saveBtn.className = 'btn btn-success';
                 saveBtn.setAttribute('aria-label', 'Guardar');
                 saveBtn.textContent = 'Guardar';
                 saveBtn.addEventListener('click', () => appForm && appForm.triggerSubmit());

--- a/src/features/ingresos/components/IngresoForm.js
+++ b/src/features/ingresos/components/IngresoForm.js
@@ -91,7 +91,7 @@ export class IngresoForm extends HTMLElement {
         if (!formEl || !descripcionField || !montoField || !monedaField || !fechaField || !submitControls) return;
 
         const amountRow = document.createElement('div');
-        amountRow.className = 'row g-2 align-items-end ingreso-monto-row';
+        amountRow.className = 'row g-2 align-items-start ingreso-monto-row';
         montoField.className = 'mb-0 col-8';
         monedaField.className = 'mb-0 col-4';
         amountRow.appendChild(montoField);

--- a/src/features/ingresos/components/IngresoForm.js
+++ b/src/features/ingresos/components/IngresoForm.js
@@ -57,7 +57,7 @@ export class IngresoForm extends HTMLElement {
     reset() {
         const form = this.querySelector('app-form');
         if (form) {
-            form.initialValues = {};
+            form.initialValues = { moneda: 'ARS' };
             this._applyMobileFirstLayout(form);
             form.clearValidationState();
         }
@@ -76,6 +76,7 @@ export class IngresoForm extends HTMLElement {
         form.fields = fields;
         form.submitText = 'Agregar ingreso';
         form.cancelText = 'Cancelar';
+        form.initialValues = { moneda: 'ARS' };
         this.appendChild(form);
         this._applyMobileFirstLayout(form);
     }

--- a/src/features/ingresos/components/IngresoForm.js
+++ b/src/features/ingresos/components/IngresoForm.js
@@ -57,7 +57,7 @@ export class IngresoForm extends HTMLElement {
     reset() {
         const form = this.querySelector('app-form');
         if (form) {
-            form.initialValues = { moneda: 'ARS' };
+            form.initialValues = {};
             this._applyMobileFirstLayout(form);
             form.clearValidationState();
         }
@@ -76,7 +76,6 @@ export class IngresoForm extends HTMLElement {
         form.fields = fields;
         form.submitText = 'Agregar ingreso';
         form.cancelText = 'Cancelar';
-        form.initialValues = { moneda: 'ARS' };
         this.appendChild(form);
         this._applyMobileFirstLayout(form);
     }

--- a/src/features/ingresos/components/IngresoForm.js
+++ b/src/features/ingresos/components/IngresoForm.js
@@ -92,8 +92,8 @@ export class IngresoForm extends HTMLElement {
 
         const amountRow = document.createElement('div');
         amountRow.className = 'row g-2 align-items-start ingreso-monto-row';
-        montoField.className = 'mb-0 col-8';
-        monedaField.className = 'mb-0 col-4';
+        montoField.className = 'mb-0 col-8 align-self-start';
+        monedaField.className = 'mb-0 col-4 align-self-start';
         amountRow.appendChild(montoField);
         amountRow.appendChild(monedaField);
 

--- a/src/features/montos/components/MontoForm.js
+++ b/src/features/montos/components/MontoForm.js
@@ -95,10 +95,8 @@ export class MontoForm extends HTMLElement {
         const fieldNames = ['monto', 'moneda', 'vencimiento'];
         const fields = fieldNames.map(fieldName => formEl.querySelector(`[data-field-name="${fieldName}"]`));
         if (fields.some(field => field === null)) return;
-
         fields.forEach(field => {
-            field.classList.remove('mb-2');
-            field.classList.add('col-12', 'col-md-4', 'mb-0');
+            field.classList.add('col-12', 'col-md-4');
             fieldsRow.appendChild(field);
         });
 
@@ -106,7 +104,7 @@ export class MontoForm extends HTMLElement {
 
         const actionRow = formEl.querySelector('[data-form-actions="true"]');
         if (actionRow) {
-            actionRow.className = 'd-flex justify-content-end gap-2 mt-2';
+            actionRow.classList.add('d-flex', 'justify-content-end', 'gap-2', 'mt-2');
             formEl.appendChild(actionRow);
         }
     }

--- a/src/features/montos/components/MontoForm.js
+++ b/src/features/montos/components/MontoForm.js
@@ -76,14 +76,14 @@ export class MontoForm extends HTMLElement {
         form.addEventListener('form:submit', e => {
             form.dispatchEvent(new CustomEvent('monto:submit', { detail: e.detail, bubbles: true, composed: true }));
         });
-        if (this.inline) {
-            this._applyInlineLayout(form);
-        }
         if (this.compactErrors) {
             this._applyCompactErrors(form);
         }
         this.appendChild(form);
         this._applyFormLayout(form);
+        if (this.inline) {
+            this._applyInlineLayout(form);
+        }
     }
 
     _applyFormLayout(appForm) {
@@ -111,14 +111,20 @@ export class MontoForm extends HTMLElement {
     _applyInlineLayout(form) {
         const formEl = form.querySelector('form');
         if (!formEl) return;
-        formEl.classList.add('flex-md-row', 'align-items-md-start');
-        formEl.querySelectorAll('[data-field-name]').forEach(field => {
-            field.classList.remove('mb-2');
-            field.classList.add('mb-0', 'flex-fill');
-        });
-        const cancelBtn = formEl.querySelector('button[type="button"]');
-        if (!cancelBtn?.parentElement) return;
-        cancelBtn.parentElement.classList.add('mt-md-4', 'flex-shrink-0');
+        const actionRow = formEl.querySelector('[data-form-actions="true"]');
+        const generalError = formEl.querySelector('[data-monto-general-error="true"]');
+
+        if (generalError) {
+            generalError.classList.add('w-100', 'mt-0');
+            if (actionRow) {
+                formEl.insertBefore(generalError, actionRow);
+            }
+        }
+
+        if (actionRow) {
+            actionRow.classList.remove('mt-md-4', 'flex-shrink-0');
+            actionRow.classList.add('mt-0', 'justify-content-end');
+        }
     }
 
     _applyCompactErrors(form) {

--- a/src/features/montos/components/MontoForm.js
+++ b/src/features/montos/components/MontoForm.js
@@ -83,6 +83,27 @@ export class MontoForm extends HTMLElement {
             this._applyCompactErrors(form);
         }
         this.appendChild(form);
+        this._applyFormLayout(form);
+    }
+
+    _applyFormLayout(appForm) {
+        const formEl = appForm.querySelector('form');
+        if (!formEl) return;
+
+        const fieldsRow = document.createElement('div');
+        fieldsRow.className = 'row g-2 align-items-end';
+
+        ['monto', 'moneda', 'vencimiento'].forEach(fieldName => {
+            const field = formEl.querySelector(`[data-field-name="${fieldName}"]`);
+            if (!field) return;
+            field.classList.remove('mb-2');
+            field.classList.add('col-12', 'col-md-4', 'mb-0');
+            fieldsRow.appendChild(field);
+        });
+
+        if (fieldsRow.children.length > 0) {
+            formEl.insertBefore(fieldsRow, formEl.firstChild);
+        }
     }
 
     _applyInlineLayout(form) {

--- a/src/features/montos/components/MontoForm.js
+++ b/src/features/montos/components/MontoForm.js
@@ -76,10 +76,9 @@ export class MontoForm extends HTMLElement {
             field.classList.remove('mb-2');
             field.classList.add('mb-0', 'flex-fill');
         });
-        const btnRow = formEl.querySelector('#cancelBtn')?.parentElement;
-        if (btnRow) {
-            btnRow.classList.add('mt-md-4', 'flex-shrink-0');
-        }
+        const cancelBtn = formEl.querySelector('#cancelBtn');
+        if (!cancelBtn?.parentElement) return;
+        cancelBtn.parentElement.classList.add('mt-md-4', 'flex-shrink-0');
     }
 }
 customElements.define('monto-form', MontoForm);

--- a/src/features/montos/components/MontoForm.js
+++ b/src/features/montos/components/MontoForm.js
@@ -122,8 +122,13 @@ export class MontoForm extends HTMLElement {
         }
 
         if (actionRow) {
-            actionRow.classList.remove('mt-md-4', 'flex-shrink-0');
-            actionRow.classList.add('mt-0', 'justify-content-end');
+            actionRow.classList.remove('mt-0', 'mt-2', 'mt-md-4', 'flex-shrink-0');
+            actionRow.classList.add('mt-3', 'justify-content-end', 'w-100');
+            const cancelBtn = actionRow.querySelector('#cancelBtn');
+            const saveBtn = actionRow.querySelector('button[type="submit"]');
+            cancelBtn?.classList.remove('btn-primary');
+            cancelBtn?.classList.add('btn-outline-secondary', 'btn-sm');
+            saveBtn?.classList.add('btn-sm');
         }
     }
 

--- a/src/features/montos/components/MontoForm.js
+++ b/src/features/montos/components/MontoForm.js
@@ -76,7 +76,7 @@ export class MontoForm extends HTMLElement {
             field.classList.remove('mb-2');
             field.classList.add('mb-0', 'flex-fill');
         });
-        const cancelBtn = formEl.querySelector('#cancelBtn');
+        const cancelBtn = formEl.querySelector('button[type="button"]');
         if (!cancelBtn?.parentElement) return;
         cancelBtn.parentElement.classList.add('mt-md-4', 'flex-shrink-0');
     }

--- a/src/features/montos/components/MontoForm.js
+++ b/src/features/montos/components/MontoForm.js
@@ -71,14 +71,14 @@ export class MontoForm extends HTMLElement {
     _applyInlineLayout(form) {
         const formEl = form.querySelector('form');
         if (!formEl) return;
-        formEl.className = 'd-flex flex-column flex-md-row align-items-md-start gap-2';
+        formEl.classList.add('flex-md-row', 'align-items-md-start');
         formEl.querySelectorAll('[data-field-name]').forEach(field => {
             field.classList.remove('mb-2');
             field.classList.add('mb-0', 'flex-fill');
         });
         const btnRow = formEl.querySelector('#cancelBtn')?.parentElement;
         if (btnRow) {
-            btnRow.className = 'd-flex justify-content-end gap-2 mt-2 mt-md-4 flex-shrink-0';
+            btnRow.classList.add('mt-md-4', 'flex-shrink-0');
         }
     }
 }

--- a/src/features/montos/components/MontoForm.js
+++ b/src/features/montos/components/MontoForm.js
@@ -16,6 +16,18 @@ export class MontoForm extends HTMLElement {
         return this._monto;
     }
 
+    get inline() {
+        return this.hasAttribute('inline');
+    }
+    set inline(value) {
+        if (value) {
+            this.setAttribute('inline', '');
+        } else {
+            this.removeAttribute('inline');
+        }
+        this.render();
+    }
+
     connectedCallback() {
         this.classList.add('d-block');
         this.render();
@@ -50,7 +62,24 @@ export class MontoForm extends HTMLElement {
         form.addEventListener('form:submit', e => {
             form.dispatchEvent(new CustomEvent('monto:submit', { detail: e.detail, bubbles: true, composed: true }));
         });
+        if (this.inline) {
+            this._applyInlineLayout(form);
+        }
         this.appendChild(form);
+    }
+
+    _applyInlineLayout(form) {
+        const formEl = form.querySelector('form');
+        if (!formEl) return;
+        formEl.className = 'd-flex flex-column flex-md-row align-items-md-start gap-2';
+        formEl.querySelectorAll('[data-field-name]').forEach(field => {
+            field.classList.remove('mb-2');
+            field.classList.add('mb-0', 'flex-fill');
+        });
+        const btnRow = formEl.querySelector('#cancelBtn')?.parentElement;
+        if (btnRow) {
+            btnRow.className = 'd-flex justify-content-end gap-2 mt-2 mt-md-4 flex-shrink-0';
+        }
     }
 }
 customElements.define('monto-form', MontoForm);

--- a/src/features/montos/components/MontoForm.js
+++ b/src/features/montos/components/MontoForm.js
@@ -104,7 +104,6 @@ export class MontoForm extends HTMLElement {
 
         const actionRow = formEl.querySelector('[data-form-actions="true"]');
         if (actionRow) {
-            actionRow.classList.add('d-flex', 'justify-content-end', 'gap-2', 'mt-2');
             formEl.appendChild(actionRow);
         }
     }

--- a/src/features/montos/components/MontoForm.js
+++ b/src/features/montos/components/MontoForm.js
@@ -28,7 +28,8 @@ export class MontoForm extends HTMLElement {
                     composed: true
                 }));
             });
-            this.form.addEventListener('form:cancel', () => {
+            this.form.addEventListener('form:cancel', (e) => {
+                e.stopPropagation();
                 this.dispatchEvent(new CustomEvent('monto:cancel', { bubbles: true, composed: true }));
             });
         }

--- a/src/features/montos/components/MontoForm.js
+++ b/src/features/montos/components/MontoForm.js
@@ -104,6 +104,12 @@ export class MontoForm extends HTMLElement {
         if (fieldsRow.children.length > 0) {
             formEl.insertBefore(fieldsRow, formEl.firstChild);
         }
+
+        const actionRow = formEl.querySelector('#cancelBtn')?.parentElement;
+        if (actionRow) {
+            actionRow.className = 'd-flex justify-content-end gap-2 mt-2';
+            formEl.appendChild(actionRow);
+        }
     }
 
     _applyInlineLayout(form) {

--- a/src/features/montos/components/MontoForm.js
+++ b/src/features/montos/components/MontoForm.js
@@ -92,20 +92,19 @@ export class MontoForm extends HTMLElement {
 
         const fieldsRow = document.createElement('div');
         fieldsRow.className = 'row g-2 align-items-end';
+        const fieldNames = ['monto', 'moneda', 'vencimiento'];
+        const fields = fieldNames.map(fieldName => formEl.querySelector(`[data-field-name="${fieldName}"]`));
+        if (fields.some(field => field === null)) return;
 
-        ['monto', 'moneda', 'vencimiento'].forEach(fieldName => {
-            const field = formEl.querySelector(`[data-field-name="${fieldName}"]`);
-            if (!field) return;
+        fields.forEach(field => {
             field.classList.remove('mb-2');
             field.classList.add('col-12', 'col-md-4', 'mb-0');
             fieldsRow.appendChild(field);
         });
 
-        if (fieldsRow.children.length > 0) {
-            formEl.insertBefore(fieldsRow, formEl.firstChild);
-        }
+        formEl.insertBefore(fieldsRow, formEl.firstChild);
 
-        const actionRow = formEl.querySelector('#cancelBtn')?.parentElement;
+        const actionRow = formEl.querySelector('[data-form-actions="true"]');
         if (actionRow) {
             actionRow.className = 'd-flex justify-content-end gap-2 mt-2';
             formEl.appendChild(actionRow);

--- a/src/features/montos/components/MontoForm.js
+++ b/src/features/montos/components/MontoForm.js
@@ -2,6 +2,8 @@
 import monedas from '../../../shared/config/monedas.js';
 import '../../../shared/components/AppForm.js';
 
+export const MONTO_FORM_GENERAL_ERROR_MESSAGE = 'Completá monto, moneda y vencimiento para agregar el monto.';
+
 export class MontoForm extends HTMLElement {
     constructor() {
         super();
@@ -24,6 +26,18 @@ export class MontoForm extends HTMLElement {
             this.setAttribute('inline', '');
         } else {
             this.removeAttribute('inline');
+        }
+        this.render();
+    }
+
+    get compactErrors() {
+        return this.hasAttribute('compact-errors');
+    }
+    set compactErrors(value) {
+        if (value) {
+            this.setAttribute('compact-errors', '');
+        } else {
+            this.removeAttribute('compact-errors');
         }
         this.render();
     }
@@ -65,6 +79,9 @@ export class MontoForm extends HTMLElement {
         if (this.inline) {
             this._applyInlineLayout(form);
         }
+        if (this.compactErrors) {
+            this._applyCompactErrors(form);
+        }
         this.appendChild(form);
     }
 
@@ -79,6 +96,45 @@ export class MontoForm extends HTMLElement {
         const cancelBtn = formEl.querySelector('button[type="button"]');
         if (!cancelBtn?.parentElement) return;
         cancelBtn.parentElement.classList.add('mt-md-4', 'flex-shrink-0');
+    }
+
+    _applyCompactErrors(form) {
+        form.querySelectorAll('.invalid-feedback').forEach(feedbackEl => {
+            feedbackEl.classList.add('d-none');
+            const input = feedbackEl.previousElementSibling;
+            if (!input) return;
+            const fieldName = input.name;
+            if (fieldName === 'monto') {
+                feedbackEl.textContent = 'Ingresá un monto válido.';
+            } else if (fieldName === 'moneda') {
+                feedbackEl.textContent = 'Seleccioná una moneda.';
+            } else if (fieldName === 'vencimiento') {
+                feedbackEl.textContent = 'Ingresá una fecha válida.';
+            } else {
+                feedbackEl.textContent = 'Campo inválido.';
+            }
+        });
+
+        const formEl = form.querySelector('form');
+        if (!formEl) return;
+        const generalError = document.createElement('div');
+        generalError.className = 'invalid-feedback mt-2 d-none';
+        generalError.dataset.montoGeneralError = 'true';
+        generalError.textContent = MONTO_FORM_GENERAL_ERROR_MESSAGE;
+        formEl.appendChild(generalError);
+
+        const clearGeneralError = () => {
+            generalError.classList.add('d-none');
+            generalError.classList.remove('d-block');
+        };
+        const showGeneralError = () => {
+            generalError.classList.remove('d-none');
+            generalError.classList.add('d-block');
+        };
+        form.addEventListener('form:validation-error', showGeneralError);
+        form.addEventListener('form:submit', clearGeneralError);
+        form.addEventListener('input', clearGeneralError);
+        form.addEventListener('change', clearGeneralError);
     }
 }
 customElements.define('monto-form', MontoForm);

--- a/src/layout/dataActions.js
+++ b/src/layout/dataActions.js
@@ -31,6 +31,16 @@ export function openSettingsModal(returnFocus) {
   });
 }
 
+function reloadHomeAfterDelete() {
+  window.setTimeout(() => {
+    if (window.location.pathname === '/') {
+      window.location.reload();
+      return;
+    }
+    window.location.assign('/');
+  }, 700);
+}
+
 export async function deleteAllData() {
   const confirmed = confirm('Vas a eliminar todos tus egresos, ingresos e inversiones. Esta acción no se puede deshacer. ¿Continuás?');
   if (!confirmed) return;
@@ -72,6 +82,7 @@ export async function deleteAllData() {
 
   if (deleted.length === 0 && failed.length === 0) {
     window.dispatchEvent(new CustomEvent('app:notify', { detail: { message: '⚠️ No había datos para borrar.', type: 'warning' } }));
+    reloadHomeAfterDelete();
     return;
   }
 
@@ -82,4 +93,7 @@ export async function deleteAllData() {
 
   const type = failed.length ? 'warning' : 'success';
   window.dispatchEvent(new CustomEvent('app:notify', { detail: { message: parts.join(' '), type } }));
+  if (failed.length === 0) {
+    reloadHomeAfterDelete();
+  }
 }

--- a/src/shared/components/AppForm.js
+++ b/src/shared/components/AppForm.js
@@ -150,6 +150,12 @@ export class AppForm extends HTMLElement {
 
             wrapper.appendChild(input);
 
+            const feedback = document.createElement('div');
+            feedback.className = 'invalid-feedback';
+            feedback.id = `${this._formId}-${name}-error`;
+            feedback.textContent = this._getFieldErrorMessage(field);
+            wrapper.appendChild(feedback);
+
             return wrapper;
         });
 
@@ -223,12 +229,33 @@ export class AppForm extends HTMLElement {
         this.querySelectorAll('[data-field-name].was-validated').forEach(field => {
             field.classList.remove('was-validated');
         });
+        this.querySelectorAll('[aria-invalid]').forEach(el => {
+            el.removeAttribute('aria-invalid');
+            el.removeAttribute('aria-describedby');
+        });
+    }
+
+    _getFieldErrorMessage(field) {
+        if (field.type === 'number') {
+            const min = field.min !== undefined ? Number(field.min) : null;
+            return (min !== null && min > 0)
+                ? `El valor debe ser un número mayor que ${min}.`
+                : 'El valor debe ser un número válido.';
+        }
+        if (field.type === 'select') return 'Seleccioná una opción válida.';
+        if (field.type === 'date') return 'Ingresá una fecha válida.';
+        return 'Este campo es obligatorio.';
     }
 
     handleInvalid(e) {
         this.form?.classList.add('was-validated');
         const invalidField = e?.target;
         if (!invalidField || invalidField === this.form) return;
+        invalidField.setAttribute('aria-invalid', 'true');
+        const feedbackId = `${this._formId}-${invalidField.name || invalidField.id}-error`;
+        if (this.querySelector(`#${feedbackId}`)) {
+            invalidField.setAttribute('aria-describedby', feedbackId);
+        }
         const fieldName = invalidField.name || invalidField.id || 'unknown_field';
         this.dispatchEvent(new CustomEvent('form:validation-error', {
             detail: {

--- a/src/shared/components/AppForm.js
+++ b/src/shared/components/AppForm.js
@@ -168,6 +168,7 @@ export class AppForm extends HTMLElement {
             // Buttons
             const btnRow = document.createElement('div');
             btnRow.className = 'd-flex justify-content-end gap-2 mt-2';
+            btnRow.dataset.formActions = 'true';
 
             const cancelBtn = document.createElement('button');
             cancelBtn.type = 'button';

--- a/test/app-form.test.js
+++ b/test/app-form.test.js
@@ -123,5 +123,57 @@ export const tests = [
         assert(!form.classList.contains('was-validated'), 'clearValidationState debe limpiar la clase was-validated');
 
         document.body.removeChild(appForm);
+    },
+
+    async function appForm_rendersInvalidFeedbackPerField() {
+        console.log('  AppForm: renders invalid-feedback elements with field-specific messages');
+        const appForm = document.createElement('app-form');
+        appForm.fields = [
+            { name: 'acreedor', type: 'text', label: 'Acreedor', required: true },
+            { name: 'monto', type: 'number', label: 'Monto', required: true, min: 0.01 },
+            { name: 'moneda', type: 'select', label: 'Moneda', options: ['ARS', 'USD'], required: true, placeholder: 'Seleccioná una moneda…' },
+            { name: 'fecha', type: 'date', label: 'Fecha', required: true }
+        ];
+        document.body.appendChild(appForm);
+
+        const acreedorWrapper = appForm.querySelector('[data-field-name="acreedor"]');
+        const montoWrapper = appForm.querySelector('[data-field-name="monto"]');
+        const monedaWrapper = appForm.querySelector('[data-field-name="moneda"]');
+        const fechaWrapper = appForm.querySelector('[data-field-name="fecha"]');
+
+        assert(acreedorWrapper.querySelector('.invalid-feedback') !== null, 'Acreedor debe tener elemento invalid-feedback');
+        assert(montoWrapper.querySelector('.invalid-feedback') !== null, 'Monto debe tener elemento invalid-feedback');
+        assert(monedaWrapper.querySelector('.invalid-feedback') !== null, 'Moneda debe tener elemento invalid-feedback');
+        assert(fechaWrapper.querySelector('.invalid-feedback') !== null, 'Fecha debe tener elemento invalid-feedback');
+
+        assert(acreedorWrapper.querySelector('.invalid-feedback').textContent === 'Este campo es obligatorio.', 'Mensaje de texto requerido correcto');
+        assert(montoWrapper.querySelector('.invalid-feedback').textContent.includes('número'), 'Mensaje numérico menciona número');
+        assert(monedaWrapper.querySelector('.invalid-feedback').textContent.includes('opción'), 'Mensaje de select menciona opción');
+        assert(fechaWrapper.querySelector('.invalid-feedback').textContent.includes('fecha'), 'Mensaje de fecha menciona fecha');
+
+        document.body.removeChild(appForm);
+    },
+
+    async function appForm_setsAriaInvalidOnInvalidSubmit() {
+        console.log('  AppForm: sets aria-invalid and aria-describedby on invalid fields after submit');
+        const appForm = document.createElement('app-form');
+        appForm.fields = [
+            { name: 'acreedor', type: 'text', label: 'Acreedor', required: true }
+        ];
+        document.body.appendChild(appForm);
+
+        const acreedorInput = appForm.querySelector('input[name="acreedor"]');
+        assert(acreedorInput.getAttribute('aria-invalid') === null, 'aria-invalid no debe estar presente antes de submit inválido');
+
+        appForm.triggerSubmit();
+
+        assert(acreedorInput.getAttribute('aria-invalid') === 'true', 'aria-invalid debe ser "true" tras submit inválido');
+        assert(acreedorInput.getAttribute('aria-describedby') !== null, 'aria-describedby debe apuntar al mensaje de error');
+
+        appForm.clearValidationState();
+        assert(acreedorInput.getAttribute('aria-invalid') === null, 'clearValidationState debe limpiar aria-invalid');
+        assert(acreedorInput.getAttribute('aria-describedby') === null, 'clearValidationState debe limpiar aria-describedby');
+
+        document.body.removeChild(appForm);
     }
 ];

--- a/test/deudas.test.js
+++ b/test/deudas.test.js
@@ -592,7 +592,14 @@ async function testAltaInlineAgregarYGuardar() {
 
     // Verify inputs exist inside monto-form > app-form
     const appFormEl = inlineForm.querySelector('app-form form');
-    assert(appFormEl.classList.contains('flex-md-row'), 'El formulario debe alinear Monto, moneda y vencimiento en línea');
+    const fieldsRow = appFormEl.firstElementChild;
+    const generalFeedback = appFormEl.querySelector('[data-monto-general-error="true"]');
+    const actionRow = appFormEl.querySelector('[data-form-actions="true"]');
+    assert(!appFormEl.classList.contains('flex-md-row'), 'El formulario inline no debe forzar flex-md-row');
+    assert(fieldsRow.classList.contains('row'), 'La primera fila inline debe contener los campos');
+    assert(generalFeedback?.previousElementSibling === fieldsRow, 'El mensaje general debe ir debajo de la fila de campos');
+    assert(generalFeedback?.nextElementSibling === actionRow, 'Las acciones deben ir debajo del mensaje general');
+    assert(actionRow?.classList.contains('justify-content-end'), 'Las acciones inline deben alinearse a la derecha');
     const montoInput = inlineForm.querySelector('input[name="monto"]');
     const monedaSelect = inlineForm.querySelector('select[name="moneda"]');
     const vencInput = inlineForm.querySelector('input[name="vencimiento"]');

--- a/test/deudas.test.js
+++ b/test/deudas.test.js
@@ -581,7 +581,7 @@ async function testAltaInlineAgregarYGuardar() {
     const inlineAddContainer = form.querySelector('#add-monto-form-container');
     assert(inlineAddContainer !== null, 'Debe existir contenedor separado para alta de monto');
     assert(!inlineAddContainer.classList.contains('d-none'), 'El formulario de alta debe estar visible');
-    assert(inlineAddContainer.nextElementSibling?.querySelector('#add-monto') !== null, 'El formulario debe estar justo arriba del botón Agregar monto');
+    assert(inlineAddContainer.nextElementSibling?.firstElementChild === form.querySelector('#add-monto'), 'El formulario debe estar justo arriba del botón Agregar monto');
     assert(tbody.querySelector('.inline-edit-row') === null, 'El alta de monto no debe renderizar una fila dentro de la tabla');
     let inlineForm = inlineAddContainer.querySelector('monto-form');
     assert(inlineForm !== null, 'Debe haber un formulario inline de alta');

--- a/test/deudas.test.js
+++ b/test/deudas.test.js
@@ -609,6 +609,47 @@ async function testAltaInlineAgregarYGuardar() {
 }
 
 // ===================================================================
+// UC8b: Alta inline — _saveInline muestra errores en campos vacíos
+// ===================================================================
+async function testAltaInlineValidacionErrores() {
+    console.log('  UC8b: Alta inline — _saveInline muestra errores cuando campos están vacíos');
+    await cleanup();
+
+    const form = document.createElement('debt-form');
+    document.body.appendChild(form);
+
+    form.openInlineAdd();
+    const tbody = form.querySelector('#montos-tbody');
+    const inlineRow = tbody.querySelector('.inline-edit-row');
+    assert(inlineRow !== null, 'Debe haber una fila inline');
+
+    const montoInput = inlineRow.querySelector('input[name="monto"]');
+    const vencInput = inlineRow.querySelector('input[name="vencimiento"]');
+
+    // Intentar guardar con campos vacíos
+    form._saveInline();
+    assert(form._inlineEditIdx === 'new', 'El inline sigue abierto tras guardar con campos inválidos');
+    assert(form.montos.length === 0, 'No se agregó ningún monto');
+    assert(montoInput.classList.contains('is-invalid'), 'Monto debe marcarse como inválido');
+    assert(montoInput.getAttribute('aria-invalid') === 'true', 'Monto debe tener aria-invalid=true');
+    const montoFeedback = montoInput.nextElementSibling;
+    assert(montoFeedback !== null && montoFeedback.classList.contains('invalid-feedback'), 'Debe haber invalid-feedback para monto');
+    assert(montoFeedback.textContent.length > 0, 'El mensaje de error de monto no debe estar vacío');
+    assert(vencInput.classList.contains('is-invalid'), 'Vencimiento debe marcarse como inválido');
+    const vencFeedback = vencInput.nextElementSibling;
+    assert(vencFeedback !== null && vencFeedback.classList.contains('invalid-feedback'), 'Debe haber invalid-feedback para vencimiento');
+
+    // Corregir el campo monto y verificar que se limpia el error
+    montoInput.value = '1000';
+    montoInput.dispatchEvent(new Event('input'));
+    assert(!montoInput.classList.contains('is-invalid'), 'Error de monto debe limpiarse al corregir');
+    assert(montoInput.getAttribute('aria-invalid') === null, 'aria-invalid debe limpiarse al corregir');
+
+    document.body.removeChild(form);
+    await cleanup();
+}
+
+// ===================================================================
 // UC9: Cancel alta inline — no modifica form.montos ni deja fila basura
 // ===================================================================
 async function testCancelarAltaInline() {
@@ -1667,6 +1708,7 @@ export const tests = [
     testAcreedorColumnMobileRender,
     testPagoToggleVisualFeedback,
     testAltaInlineAgregarYGuardar,
+    testAltaInlineValidacionErrores,
     testCancelarAltaInline,
     testEdicionInlineGuardar,
     testCancelarEdicionInline,

--- a/test/deudas.test.js
+++ b/test/deudas.test.js
@@ -11,6 +11,7 @@ import { summarizeDebtListTotals } from '../src/features/deudas/components/DebtL
 // Import DebtDetailModal component
 import '../src/features/deudas/components/DebtDetailModal.js';
 import '../src/features/montos/components/DuplicateMontoModal.js';
+import { MONTO_FORM_GENERAL_ERROR_MESSAGE } from '../src/features/montos/components/MontoForm.js';
 import '../src/features/deudas/components/DebtForm.js';
 import '../src/features/deudas/components/DebtModal.js';
 import '../src/features/deudas/components/DebtEntityShell.js';
@@ -559,9 +560,9 @@ async function testPagoToggleVisualFeedback() {
 }
 
 // ===================================================================
-// UC8: Alta inline — openInlineAdd() muestra formulario separado de la tabla
-// Verifica que _inlineEditIdx = 'new' y hay un formulario inline arriba del botón Agregar monto.
-// Al guardar con datos válidos, form.montos crece en 1 y la fila vuelve a lectura.
+// UC8: Alta inline — openInlineAdd() muestra sólo el formulario de monto
+// Verifica estados de visibilidad: en creating se ocultan tabla y botón Agregar monto.
+// Al guardar con datos válidos, form.montos crece en 1 y vuelve el modo lista.
 // ===================================================================
 async function testAltaInlineAgregarYGuardar() {
     console.log('  UC8: Alta inline — agregar monto y guardar');
@@ -574,15 +575,18 @@ async function testAltaInlineAgregarYGuardar() {
 
     // Abrir inline add
     form.openInlineAdd();
+    assert(form._amountMode === 'creating', '_amountMode debe ser "creating"');
     assert(form._inlineEditIdx === 'new', '_inlineEditIdx debe ser "new"');
 
-    const tbody = form.querySelector('#montos-tbody');
-    assert(tbody !== null, 'tbody existe');
+    const tableWrapper = form.querySelector('#montos-table-wrapper');
+    const addMontoBtnRow = form.querySelector('#add-monto-btn-row');
+    const title = form.querySelector('#monto-form-title');
     const inlineAddContainer = form.querySelector('#add-monto-form-container');
     assert(inlineAddContainer !== null, 'Debe existir contenedor separado para alta de monto');
     assert(!inlineAddContainer.classList.contains('d-none'), 'El formulario de alta debe estar visible');
-    assert(inlineAddContainer.nextElementSibling?.firstElementChild === form.querySelector('#add-monto'), 'El formulario debe estar justo arriba del botón Agregar monto');
-    assert(tbody.querySelector('.inline-edit-row') === null, 'El alta de monto no debe renderizar una fila dentro de la tabla');
+    assert(tableWrapper.classList.contains('d-none'), 'La tabla/lista debe ocultarse al crear');
+    assert(addMontoBtnRow.classList.contains('d-none'), 'El botón Agregar monto debe ocultarse al crear');
+    assert(title.textContent === 'Nuevo monto', 'El formulario debe titularse "Nuevo monto"');
     let inlineForm = inlineAddContainer.querySelector('monto-form');
     assert(inlineForm !== null, 'Debe haber un formulario inline de alta');
 
@@ -600,6 +604,7 @@ async function testAltaInlineAgregarYGuardar() {
         bubbles: true,
         composed: true
     }));
+    assert(form._amountMode === 'idle', 'Debe volver a modo lista tras guardar');
     assert(form._inlineEditIdx === null, 'Inline cerrado tras guardar');
     assert(form.montos.length === 1, 'montos debe tener 1 elemento tras guardar');
     assert(form.montos[0].monto === 7500, 'Monto guardado: 7500');
@@ -611,13 +616,15 @@ async function testAltaInlineAgregarYGuardar() {
     inlineForm = inlineAddContainer.querySelector('monto-form');
     assert(inlineForm === null, 'Formulario inline desaparecido tras guardar');
     assert(inlineAddContainer.classList.contains('d-none'), 'El contenedor de alta vuelve a ocultarse tras guardar');
+    assert(!tableWrapper.classList.contains('d-none'), 'La tabla/lista vuelve a mostrarse tras guardar');
+    assert(!addMontoBtnRow.classList.contains('d-none'), 'El botón Agregar monto vuelve a mostrarse tras guardar');
 
     document.body.removeChild(form);
     await cleanup();
 }
 
 // ===================================================================
-// UC8b: Alta inline — muestra errores ARIA en campos vacíos (vía AppForm)
+// UC8b: Alta inline — marca campos inválidos y muestra error general corto
 // ===================================================================
 async function testAltaInlineValidacionErrores() {
     console.log('  UC8b: Alta inline — muestra errores ARIA cuando campos están vacíos');
@@ -633,18 +640,18 @@ async function testAltaInlineValidacionErrores() {
 
     const montoInput = inlineForm.querySelector('input[name="monto"]');
     const vencInput = inlineForm.querySelector('input[name="vencimiento"]');
+    const appForm = inlineForm.querySelector('app-form');
 
     // Intentar guardar con campos vacíos — AppForm fires invalid events, not is-invalid class
-    inlineForm.querySelector('app-form').triggerSubmit();
+    appForm.triggerSubmit();
     assert(form._inlineEditIdx === 'new', 'El inline sigue abierto tras guardar con campos inválidos');
     assert(form.montos.length === 0, 'No se agregó ningún monto');
     assert(montoInput.getAttribute('aria-invalid') === 'true', 'Monto debe tener aria-invalid=true');
-    const montoFeedback = montoInput.nextElementSibling;
-    assert(montoFeedback !== null && montoFeedback.classList.contains('invalid-feedback'), 'Debe haber invalid-feedback para monto');
-    assert(montoFeedback.textContent.length > 0, 'El mensaje de error de monto no debe estar vacío');
     assert(vencInput.getAttribute('aria-invalid') === 'true', 'Vencimiento debe tener aria-invalid=true');
-    const vencFeedback = vencInput.nextElementSibling;
-    assert(vencFeedback !== null && vencFeedback.classList.contains('invalid-feedback'), 'Debe haber invalid-feedback para vencimiento');
+    const generalFeedback = appForm.querySelector('[data-monto-general-error="true"]');
+    assert(generalFeedback !== null, 'Debe existir mensaje general de validación');
+    assert(generalFeedback.classList.contains('d-block'), 'El mensaje general de validación debe mostrarse');
+    assert(generalFeedback.textContent === MONTO_FORM_GENERAL_ERROR_MESSAGE, 'El mensaje general debe ser corto y claro');
 
     document.body.removeChild(form);
     await cleanup();
@@ -666,14 +673,16 @@ async function testCancelarAltaInline() {
 
     form.openInlineAdd();
     assert(form._inlineEditIdx === 'new', 'Inline add abierto');
+    assert(form._amountMode === 'creating', 'Debe quedar en modo creating');
 
     form._cancelInline();
+    assert(form._amountMode === 'idle', 'Debe volver a modo idle tras cancelar');
     assert(form._inlineEditIdx === null, 'Inline cerrado tras cancelar');
     assert(form.montos.length === 1, 'montos sigue con 1 elemento (sin cambios)');
     assert(form.montos[0].monto === 5000, 'El monto original no fue modificado');
 
-    const inlineRow = form.querySelector('.inline-edit-row');
-    assert(inlineRow === null, 'No hay fila inline tras cancelar');
+    const inlineForm = form.querySelector('#add-monto-form-container monto-form');
+    assert(inlineForm === null, 'No hay formulario inline tras cancelar');
 
     document.body.removeChild(form);
     await cleanup();
@@ -701,9 +710,13 @@ async function testEdicionInlineGuardar() {
     assert(form._inlineEditRef !== null, '_inlineEditRef cargado');
     assert(form._inlineEditRef.monto === 1000, 'Original guardado: 1000');
 
-    const tbody = form.querySelector('#montos-tbody');
-    const inlineRow = tbody.querySelector('.inline-edit-row');
-    assert(inlineRow !== null, 'Fila inline presente para edición');
+    assert(form._amountMode === 'editing', 'Debe quedar en modo editing');
+    const inlineContainer = form.querySelector('#add-monto-form-container');
+    const inlineRow = inlineContainer.querySelector('monto-form');
+    assert(inlineRow !== null, 'Formulario inline presente para edición');
+    assert(form.querySelector('#monto-form-title').textContent === 'Editar monto', 'Debe usar título "Editar monto"');
+    assert(form.querySelector('#montos-table-wrapper').classList.contains('d-none'), 'La tabla debe ocultarse durante edición');
+    assert(form.querySelector('#add-monto-btn-row').classList.contains('d-none'), 'El botón Agregar monto debe ocultarse durante edición');
 
     const montoInput = inlineRow.querySelector('input[name="monto"]');
     assert(montoInput.value === '1000', 'Input monto precargado con 1000');
@@ -720,6 +733,7 @@ async function testEdicionInlineGuardar() {
         bubbles: true,
         composed: true
     }));
+    assert(form._amountMode === 'idle', 'Debe volver a modo lista tras guardar edición');
     assert(form._inlineEditIdx === null, 'Inline cerrado tras guardar');
     assert(form.montos.length === 2, 'Sigue con 2 montos');
 
@@ -748,12 +762,12 @@ async function testCancelarEdicionInline() {
     form.openInlineEdit(form.montos[0], 0);
 
     // Modificar inputs pero cancelar sin guardar
-    const tbody = form.querySelector('#montos-tbody');
-    const inlineRow = tbody.querySelector('.inline-edit-row');
+    const inlineRow = form.querySelector('#add-monto-form-container monto-form');
     inlineRow.querySelector('input[name="monto"]').value = '99999';
 
     form._cancelInline();
 
+    assert(form._amountMode === 'idle', 'Cancelar edición vuelve a modo lista');
     assert(form._inlineEditIdx === null, 'Inline cerrado tras cancelar');
     assert(form.montos.length === 1, 'Sigue con 1 monto');
     assert(form.montos[0].monto === 9000, 'Monto original sin cambios: 9000');
@@ -1006,8 +1020,12 @@ async function testShowFormErrorNearMontos() {
     assert(montosList.contains(errEl), 'El error debe renderizarse dentro del bloque de montos');
     assert(errEl.parentElement === montosFieldContainer, 'El error debe renderizarse dentro del contenedor principal de Montos');
     assert(errEl.previousElementSibling === montosTableWrapper, 'El error debe aparecer debajo del wrapper de la tabla de montos');
-    assert(errEl.nextElementSibling === form.querySelector('#add-monto-form-container'), 'El contenedor del formulario de alta debe quedar debajo del mensaje de error');
-    assert(errEl.nextElementSibling?.nextElementSibling?.querySelector('#add-monto') !== null, 'El botón Agregar monto debe quedar debajo del mensaje de error y del formulario de alta');
+    const montoFormTitle = form.querySelector('#monto-form-title');
+    const montoFormContainer = form.querySelector('#add-monto-form-container');
+    const addMontoBtn = form.querySelector('#add-monto');
+    assert(errEl.nextElementSibling === montoFormTitle, 'El título del formulario de monto debe quedar debajo del mensaje de error');
+    assert(montoFormTitle.nextElementSibling === montoFormContainer, 'El contenedor del formulario de alta debe quedar debajo del título');
+    assert(montoFormContainer.nextElementSibling?.querySelector('#add-monto') === addMontoBtn, 'El botón Agregar monto debe quedar debajo del mensaje de error y del formulario de alta');
     assert(montosTableWrapper.classList.contains('border-danger'), 'Solo la tabla de Montos debe marcarse visualmente como inválida');
     assert(!montosFieldContainer.classList.contains('border-danger'), 'El contenedor general de Montos no debe marcarse en rojo');
     assert(!errEl.classList.contains('d-none'), 'El mensaje de error de montos debe hacerse visible');

--- a/test/deudas.test.js
+++ b/test/deudas.test.js
@@ -595,11 +595,16 @@ async function testAltaInlineAgregarYGuardar() {
     const fieldsRow = appFormEl.firstElementChild;
     const generalFeedback = appFormEl.querySelector('[data-monto-general-error="true"]');
     const actionRow = appFormEl.querySelector('[data-form-actions="true"]');
+    const cancelBtn = actionRow.querySelector('#cancelBtn');
+    const saveBtn = actionRow.querySelector('button[type="submit"]');
     assert(!appFormEl.classList.contains('flex-md-row'), 'El formulario inline no debe forzar flex-md-row');
     assert(fieldsRow.classList.contains('row'), 'La primera fila inline debe contener los campos');
     assert(generalFeedback?.previousElementSibling === fieldsRow, 'El mensaje general debe ir debajo de la fila de campos');
     assert(generalFeedback?.nextElementSibling === actionRow, 'Las acciones deben ir debajo del mensaje general');
     assert(actionRow?.classList.contains('justify-content-end'), 'Las acciones inline deben alinearse a la derecha');
+    assert(actionRow?.classList.contains('mt-3'), 'Las acciones inline deben separarse visualmente de los campos');
+    assert(cancelBtn?.classList.contains('btn-outline-secondary'), 'Cancelar inline debe verse como acción secundaria');
+    assert(saveBtn?.classList.contains('btn-success'), 'Guardar inline debe mantenerse como acción primaria verde');
     const montoInput = inlineForm.querySelector('input[name="monto"]');
     const monedaSelect = inlineForm.querySelector('select[name="moneda"]');
     const vencInput = inlineForm.querySelector('input[name="vencimiento"]');
@@ -1098,6 +1103,7 @@ async function testDebtModalInlineMontoCancelDoesNotCloseModal() {
 
     const modal = document.createElement('debt-modal');
     document.body.appendChild(modal);
+    await new Promise(resolve => setTimeout(resolve, 0));
 
     let closeCalls = 0;
     const origClose = modal.ui.close.bind(modal.ui);
@@ -1106,7 +1112,16 @@ async function testDebtModalInlineMontoCancelDoesNotCloseModal() {
     const debtForm = modal.querySelector('debt-form');
     debtForm.openInlineAdd();
     const inlineMontoForm = debtForm.querySelector('#add-monto-form-container app-form');
+    const inlineActionRow = inlineMontoForm?.querySelector('[data-form-actions="true"]');
+    const inlineCancelBtn = inlineActionRow?.querySelector('#cancelBtn');
+    const inlineSaveBtn = inlineActionRow?.querySelector('button[type="submit"]');
+    const footerCancelBtn = modal.querySelector('.modal-footer .btn.btn-primary');
+    const footerSaveBtn = modal.querySelector('.modal-footer .btn.btn-success');
     assert(inlineMontoForm !== null, 'Debe existir app-form inline para cancelar monto');
+    assert(inlineCancelBtn?.classList.contains('btn-sm'), 'Cancelar del monto inline debe usar tamaño chico');
+    assert(inlineSaveBtn?.classList.contains('btn-sm'), 'Guardar del monto inline debe usar tamaño chico');
+    assert(!footerCancelBtn?.classList.contains('btn-sm'), 'Cancelar del footer del modal no debe usar tamaño chico');
+    assert(!footerSaveBtn?.classList.contains('btn-sm'), 'Guardar del footer del modal no debe usar tamaño chico');
 
     inlineMontoForm.dispatchEvent(new CustomEvent('form:cancel', { bubbles: true, composed: true }));
 

--- a/test/deudas.test.js
+++ b/test/deudas.test.js
@@ -559,8 +559,8 @@ async function testPagoToggleVisualFeedback() {
 }
 
 // ===================================================================
-// UC8: Alta inline — openInlineAdd() inserta fila inline al final
-// Verifica que _inlineEditIdx = 'new' y hay una .inline-edit-row en el tbody.
+// UC8: Alta inline — openInlineAdd() muestra formulario separado de la tabla
+// Verifica que _inlineEditIdx = 'new' y hay un formulario inline arriba del botón Agregar monto.
 // Al guardar con datos válidos, form.montos crece en 1 y la fila vuelve a lectura.
 // ===================================================================
 async function testAltaInlineAgregarYGuardar() {
@@ -578,17 +578,24 @@ async function testAltaInlineAgregarYGuardar() {
 
     const tbody = form.querySelector('#montos-tbody');
     assert(tbody !== null, 'tbody existe');
-    let inlineRow = tbody.querySelector('.inline-edit-row');
-    assert(inlineRow !== null, 'Debe haber una fila inline');
+    const inlineAddContainer = form.querySelector('#add-monto-form-container');
+    assert(inlineAddContainer !== null, 'Debe existir contenedor separado para alta de monto');
+    assert(!inlineAddContainer.classList.contains('d-none'), 'El formulario de alta debe estar visible');
+    assert(inlineAddContainer.nextElementSibling?.querySelector('#add-monto') !== null, 'El formulario debe estar justo arriba del botón Agregar monto');
+    assert(tbody.querySelector('.inline-edit-row') === null, 'El alta de monto no debe renderizar una fila dentro de la tabla');
+    let inlineForm = inlineAddContainer.querySelector('monto-form');
+    assert(inlineForm !== null, 'Debe haber un formulario inline de alta');
 
     // Verify inputs exist inside monto-form > app-form
-    const montoInput = inlineRow.querySelector('input[name="monto"]');
-    const monedaSelect = inlineRow.querySelector('select[name="moneda"]');
-    const vencInput = inlineRow.querySelector('input[name="vencimiento"]');
+    const appFormEl = inlineForm.querySelector('app-form form');
+    assert(appFormEl.classList.contains('flex-md-row'), 'El formulario debe alinear Monto, moneda y vencimiento en línea');
+    const montoInput = inlineForm.querySelector('input[name="monto"]');
+    const monedaSelect = inlineForm.querySelector('select[name="moneda"]');
+    const vencInput = inlineForm.querySelector('input[name="vencimiento"]');
     assert(montoInput !== null && monedaSelect !== null && vencInput !== null, 'Inputs del inline presentes');
 
     // Guardar via form:submit directo (mismo patrón que montos.test.js UC1)
-    inlineRow.querySelector('app-form').dispatchEvent(new CustomEvent('form:submit', {
+    inlineForm.querySelector('app-form').dispatchEvent(new CustomEvent('form:submit', {
         detail: { monto: '7500', moneda: 'ARS', vencimiento: '2026-07-15' },
         bubbles: true,
         composed: true
@@ -600,9 +607,10 @@ async function testAltaInlineAgregarYGuardar() {
     assert(form.montos[0].vencimiento === '2026-07-15', 'Vencimiento guardado');
     assert(form.montos[0].pagado === false, 'pagado = false por defecto');
 
-    // La fila inline ya no debe estar presente
-    inlineRow = tbody.querySelector('.inline-edit-row');
-    assert(inlineRow === null, 'Fila inline desaparecida tras guardar');
+    // El formulario inline ya no debe estar presente
+    inlineForm = inlineAddContainer.querySelector('monto-form');
+    assert(inlineForm === null, 'Formulario inline desaparecido tras guardar');
+    assert(inlineAddContainer.classList.contains('d-none'), 'El contenedor de alta vuelve a ocultarse tras guardar');
 
     document.body.removeChild(form);
     await cleanup();
@@ -619,15 +627,15 @@ async function testAltaInlineValidacionErrores() {
     document.body.appendChild(form);
 
     form.openInlineAdd();
-    const tbody = form.querySelector('#montos-tbody');
-    const inlineRow = tbody.querySelector('.inline-edit-row');
-    assert(inlineRow !== null, 'Debe haber una fila inline');
+    const inlineAddContainer = form.querySelector('#add-monto-form-container');
+    const inlineForm = inlineAddContainer.querySelector('monto-form');
+    assert(inlineForm !== null, 'Debe haber un formulario inline de alta');
 
-    const montoInput = inlineRow.querySelector('input[name="monto"]');
-    const vencInput = inlineRow.querySelector('input[name="vencimiento"]');
+    const montoInput = inlineForm.querySelector('input[name="monto"]');
+    const vencInput = inlineForm.querySelector('input[name="vencimiento"]');
 
     // Intentar guardar con campos vacíos — AppForm fires invalid events, not is-invalid class
-    inlineRow.querySelector('app-form').triggerSubmit();
+    inlineForm.querySelector('app-form').triggerSubmit();
     assert(form._inlineEditIdx === 'new', 'El inline sigue abierto tras guardar con campos inválidos');
     assert(form.montos.length === 0, 'No se agregó ningún monto');
     assert(montoInput.getAttribute('aria-invalid') === 'true', 'Monto debe tener aria-invalid=true');
@@ -998,7 +1006,8 @@ async function testShowFormErrorNearMontos() {
     assert(montosList.contains(errEl), 'El error debe renderizarse dentro del bloque de montos');
     assert(errEl.parentElement === montosFieldContainer, 'El error debe renderizarse dentro del contenedor principal de Montos');
     assert(errEl.previousElementSibling === montosTableWrapper, 'El error debe aparecer debajo del wrapper de la tabla de montos');
-    assert(errEl.nextElementSibling?.querySelector('#add-monto') !== null, 'El botón Agregar monto debe quedar debajo del mensaje de error');
+    assert(errEl.nextElementSibling === form.querySelector('#add-monto-form-container'), 'El contenedor del formulario de alta debe quedar debajo del mensaje de error');
+    assert(errEl.nextElementSibling?.nextElementSibling?.querySelector('#add-monto') !== null, 'El botón Agregar monto debe quedar debajo del mensaje de error y del formulario de alta');
     assert(montosTableWrapper.classList.contains('border-danger'), 'Solo la tabla de Montos debe marcarse visualmente como inválida');
     assert(!montosFieldContainer.classList.contains('border-danger'), 'El contenedor general de Montos no debe marcarse en rojo');
     assert(!errEl.classList.contains('d-none'), 'El mensaje de error de montos debe hacerse visible');
@@ -1071,7 +1080,7 @@ async function testDebtModalInlineMontoCancelDoesNotCloseModal() {
 
     const debtForm = modal.querySelector('debt-form');
     debtForm.openInlineAdd();
-    const inlineMontoForm = debtForm.querySelector('.inline-edit-row app-form');
+    const inlineMontoForm = debtForm.querySelector('#add-monto-form-container app-form');
     assert(inlineMontoForm !== null, 'Debe existir app-form inline para cancelar monto');
 
     inlineMontoForm.dispatchEvent(new CustomEvent('form:cancel', { bubbles: true, composed: true }));

--- a/test/deudas.test.js
+++ b/test/deudas.test.js
@@ -1056,6 +1056,33 @@ async function testDebtModalCancelClosesModal() {
     document.body.removeChild(modal);
 }
 
+// ===================================================================
+// UC17b: Cancelar monto inline no debe cerrar el DebtModal
+// ===================================================================
+async function testDebtModalInlineMontoCancelDoesNotCloseModal() {
+    console.log('  UC17b: Cancelar monto inline no cierra el modal de deuda');
+
+    const modal = document.createElement('debt-modal');
+    document.body.appendChild(modal);
+
+    let closeCalls = 0;
+    const origClose = modal.ui.close.bind(modal.ui);
+    modal.ui.close = () => { closeCalls += 1; };
+
+    const debtForm = modal.querySelector('debt-form');
+    debtForm.openInlineAdd();
+    const inlineCancelSource = debtForm.querySelector('.inline-edit-row app-form');
+    assert(inlineCancelSource !== null, 'Debe existir app-form inline para cancelar monto');
+
+    inlineCancelSource.dispatchEvent(new CustomEvent('form:cancel', { bubbles: true, composed: true }));
+
+    assert(closeCalls === 0, 'Cancelar el monto inline no debe cerrar el modal de deuda');
+    assert(debtForm._inlineEditIdx === null, 'Cancelar monto inline debe cerrar sólo la fila inline');
+
+    modal.ui.close = origClose;
+    document.body.removeChild(modal);
+}
+
 async function testDebtModalFooterUxValidacionConsistente() {
     console.log('  UC18: DebtModal mantiene Guardar habilitado y valida al enviar desde el footer');
 
@@ -1719,6 +1746,7 @@ export const tests = [
     testShowFormErrorNearMontos,
     testDebtFormRequiereMontosAlEnviar,
     testDebtModalCancelClosesModal,
+    testDebtModalInlineMontoCancelDoesNotCloseModal,
     testDebtModalFooterUxValidacionConsistente,
     testDebtModalReopenClearsValidationState,
     testDebtEntityShellRenderVacio,

--- a/test/deudas.test.js
+++ b/test/deudas.test.js
@@ -1071,10 +1071,10 @@ async function testDebtModalInlineMontoCancelDoesNotCloseModal() {
 
     const debtForm = modal.querySelector('debt-form');
     debtForm.openInlineAdd();
-    const inlineCancelSource = debtForm.querySelector('.inline-edit-row app-form');
-    assert(inlineCancelSource !== null, 'Debe existir app-form inline para cancelar monto');
+    const inlineMontoForm = debtForm.querySelector('.inline-edit-row app-form');
+    assert(inlineMontoForm !== null, 'Debe existir app-form inline para cancelar monto');
 
-    inlineCancelSource.dispatchEvent(new CustomEvent('form:cancel', { bubbles: true, composed: true }));
+    inlineMontoForm.dispatchEvent(new CustomEvent('form:cancel', { bubbles: true, composed: true }));
 
     assert(closeCalls === 0, 'Cancelar el monto inline no debe cerrar el modal de deuda');
     assert(debtForm._inlineEditIdx === null, 'Cancelar monto inline debe cerrar sólo la fila inline');

--- a/test/deudas.test.js
+++ b/test/deudas.test.js
@@ -581,18 +581,18 @@ async function testAltaInlineAgregarYGuardar() {
     let inlineRow = tbody.querySelector('.inline-edit-row');
     assert(inlineRow !== null, 'Debe haber una fila inline');
 
-    // Rellenar los inputs
+    // Verify inputs exist inside monto-form > app-form
     const montoInput = inlineRow.querySelector('input[name="monto"]');
     const monedaSelect = inlineRow.querySelector('select[name="moneda"]');
     const vencInput = inlineRow.querySelector('input[name="vencimiento"]');
     assert(montoInput !== null && monedaSelect !== null && vencInput !== null, 'Inputs del inline presentes');
 
-    montoInput.value = '7500';
-    monedaSelect.value = 'ARS';
-    vencInput.value = '2026-07-15';
-
-    // Guardar inline
-    form._saveInline();
+    // Guardar via form:submit directo (mismo patrón que montos.test.js UC1)
+    inlineRow.querySelector('app-form').dispatchEvent(new CustomEvent('form:submit', {
+        detail: { monto: '7500', moneda: 'ARS', vencimiento: '2026-07-15' },
+        bubbles: true,
+        composed: true
+    }));
     assert(form._inlineEditIdx === null, 'Inline cerrado tras guardar');
     assert(form.montos.length === 1, 'montos debe tener 1 elemento tras guardar');
     assert(form.montos[0].monto === 7500, 'Monto guardado: 7500');
@@ -609,10 +609,10 @@ async function testAltaInlineAgregarYGuardar() {
 }
 
 // ===================================================================
-// UC8b: Alta inline — _saveInline muestra errores en campos vacíos
+// UC8b: Alta inline — muestra errores ARIA en campos vacíos (vía AppForm)
 // ===================================================================
 async function testAltaInlineValidacionErrores() {
-    console.log('  UC8b: Alta inline — _saveInline muestra errores cuando campos están vacíos');
+    console.log('  UC8b: Alta inline — muestra errores ARIA cuando campos están vacíos');
     await cleanup();
 
     const form = document.createElement('debt-form');
@@ -626,24 +626,17 @@ async function testAltaInlineValidacionErrores() {
     const montoInput = inlineRow.querySelector('input[name="monto"]');
     const vencInput = inlineRow.querySelector('input[name="vencimiento"]');
 
-    // Intentar guardar con campos vacíos
-    form._saveInline();
+    // Intentar guardar con campos vacíos — AppForm fires invalid events, not is-invalid class
+    inlineRow.querySelector('app-form').triggerSubmit();
     assert(form._inlineEditIdx === 'new', 'El inline sigue abierto tras guardar con campos inválidos');
     assert(form.montos.length === 0, 'No se agregó ningún monto');
-    assert(montoInput.classList.contains('is-invalid'), 'Monto debe marcarse como inválido');
     assert(montoInput.getAttribute('aria-invalid') === 'true', 'Monto debe tener aria-invalid=true');
     const montoFeedback = montoInput.nextElementSibling;
     assert(montoFeedback !== null && montoFeedback.classList.contains('invalid-feedback'), 'Debe haber invalid-feedback para monto');
     assert(montoFeedback.textContent.length > 0, 'El mensaje de error de monto no debe estar vacío');
-    assert(vencInput.classList.contains('is-invalid'), 'Vencimiento debe marcarse como inválido');
+    assert(vencInput.getAttribute('aria-invalid') === 'true', 'Vencimiento debe tener aria-invalid=true');
     const vencFeedback = vencInput.nextElementSibling;
     assert(vencFeedback !== null && vencFeedback.classList.contains('invalid-feedback'), 'Debe haber invalid-feedback para vencimiento');
-
-    // Corregir el campo monto y verificar que se limpia el error
-    montoInput.value = '1000';
-    montoInput.dispatchEvent(new Event('input'));
-    assert(!montoInput.classList.contains('is-invalid'), 'Error de monto debe limpiarse al corregir');
-    assert(montoInput.getAttribute('aria-invalid') === null, 'aria-invalid debe limpiarse al corregir');
 
     document.body.removeChild(form);
     await cleanup();
@@ -714,7 +707,11 @@ async function testEdicionInlineGuardar() {
     const monedaSelect = inlineRow.querySelector('select[name="moneda"]');
     monedaSelect.value = 'ARS';
 
-    form._saveInline();
+    inlineRow.querySelector('app-form').dispatchEvent(new CustomEvent('form:submit', {
+        detail: { monto: '1500', moneda: 'ARS', vencimiento: '2026-05-10' },
+        bubbles: true,
+        composed: true
+    }));
     assert(form._inlineEditIdx === null, 'Inline cerrado tras guardar');
     assert(form.montos.length === 2, 'Sigue con 2 montos');
 

--- a/test/ingresos.test.js
+++ b/test/ingresos.test.js
@@ -131,6 +131,8 @@ async function testIngresoFormLayoutMobileFirst() {
     assert(formEl.children[2] === fechaField, 'Fecha debe ir después del grupo Monto+Moneda');
     assert(montoField.classList.contains('col-8'), 'Monto debe priorizar mayor ancho');
     assert(monedaField.classList.contains('col-4'), 'Moneda debe ocupar menor ancho');
+    assert(montoField.classList.contains('align-self-start'), 'Monto debe alinearse arriba dentro de la fila');
+    assert(monedaField.classList.contains('align-self-start'), 'Moneda debe alinearse arriba dentro de la fila');
 
     document.body.removeChild(ingresoForm);
 }

--- a/test/montos.test.js
+++ b/test/montos.test.js
@@ -325,6 +325,36 @@ async function testMontoFormLayoutCamposYAcciones() {
     await cleanup();
 }
 
+async function testMontoFormInlineLayoutSeparatesValidationAndActions() {
+    console.log('  UC4d: MontoForm inline mantiene validación y acciones debajo de los campos');
+    await cleanup();
+
+    const montoForm = document.createElement('monto-form');
+    montoForm.inline = true;
+    montoForm.compactErrors = true;
+    document.body.appendChild(montoForm);
+    await customElements.whenDefined('monto-form');
+    await Promise.resolve();
+
+    const formEl = montoForm.querySelector('app-form form');
+    const fieldsRow = formEl.firstElementChild;
+    const generalError = formEl.querySelector('[data-monto-general-error="true"]');
+    const actionRow = formEl.querySelector('[data-form-actions="true"]');
+
+    assert(!formEl.classList.contains('flex-md-row'), 'El inline no debe forzar flex-md-row');
+    assert(fieldsRow.classList.contains('row'), 'La primera fila inline debe contener los campos');
+    assert(generalError !== null, 'El inline debe renderizar el mensaje general compacto');
+    assert(generalError.previousElementSibling === fieldsRow, 'El mensaje general debe ir debajo de la fila de campos');
+    assert(generalError.nextElementSibling === actionRow, 'La fila de acciones debe ir debajo del mensaje general');
+    assert(generalError.classList.contains('w-100'), 'El mensaje general debe ocupar todo el ancho');
+    assert(actionRow.classList.contains('justify-content-end'), 'Las acciones inline deben alinearse a la derecha');
+    assert(actionRow.querySelector('#cancelBtn') !== null, 'La fila de acciones inline debe incluir Cancelar');
+    assert(actionRow.querySelector('button[type="submit"]') !== null, 'La fila de acciones inline debe incluir Guardar');
+
+    document.body.removeChild(montoForm);
+    await cleanup();
+}
+
 // ===================================================================
 // UC5: Flujo completo — crear deuda con montos via DebtForm, listar
 // por mes, marcar pagado, verificar totales, eliminar monto individual
@@ -460,6 +490,7 @@ export const tests = [
     testCancelarFormularios,
     testMontosFormsUxValidacionConsistente,
     testMontoFormLayoutCamposYAcciones,
+    testMontoFormInlineLayoutSeparatesValidationAndActions,
     testFlujoCompletoMontosViaDebtForm,
     testTotalesMixtosPorMoneda
 ];

--- a/test/montos.test.js
+++ b/test/montos.test.js
@@ -340,6 +340,8 @@ async function testMontoFormInlineLayoutSeparatesValidationAndActions() {
     const fieldsRow = formEl.firstElementChild;
     const generalError = formEl.querySelector('[data-monto-general-error="true"]');
     const actionRow = formEl.querySelector('[data-form-actions="true"]');
+    const cancelBtn = actionRow.querySelector('#cancelBtn');
+    const saveBtn = actionRow.querySelector('button[type="submit"]');
 
     assert(!formEl.classList.contains('flex-md-row'), 'El inline no debe forzar flex-md-row');
     assert(fieldsRow.classList.contains('row'), 'La primera fila inline debe contener los campos');
@@ -348,8 +350,13 @@ async function testMontoFormInlineLayoutSeparatesValidationAndActions() {
     assert(generalError.nextElementSibling === actionRow, 'La fila de acciones debe ir debajo del mensaje general');
     assert(generalError.classList.contains('w-100'), 'El mensaje general debe ocupar todo el ancho');
     assert(actionRow.classList.contains('justify-content-end'), 'Las acciones inline deben alinearse a la derecha');
-    assert(actionRow.querySelector('#cancelBtn') !== null, 'La fila de acciones inline debe incluir Cancelar');
-    assert(actionRow.querySelector('button[type="submit"]') !== null, 'La fila de acciones inline debe incluir Guardar');
+    assert(actionRow.classList.contains('mt-3'), 'Las acciones inline deben separarse de los campos con margen superior');
+    assert(cancelBtn !== null, 'La fila de acciones inline debe incluir Cancelar');
+    assert(saveBtn !== null, 'La fila de acciones inline debe incluir Guardar');
+    assert(cancelBtn.classList.contains('btn-outline-secondary'), 'Cancelar inline debe verse como acción secundaria liviana');
+    assert(cancelBtn.classList.contains('btn-sm'), 'Cancelar inline debe usar tamaño chico');
+    assert(saveBtn.classList.contains('btn-success'), 'Guardar inline debe mantenerse como acción primaria verde');
+    assert(saveBtn.classList.contains('btn-sm'), 'Guardar inline debe usar tamaño chico');
 
     document.body.removeChild(montoForm);
     await cleanup();

--- a/test/montos.test.js
+++ b/test/montos.test.js
@@ -302,6 +302,8 @@ async function testMontoFormLayoutCamposYAcciones() {
 
     const montoForm = document.createElement('monto-form');
     document.body.appendChild(montoForm);
+    await customElements.whenDefined('monto-form');
+    await Promise.resolve();
 
     const formEl = montoForm.querySelector('app-form form');
     const fieldsRow = formEl.firstElementChild;

--- a/test/montos.test.js
+++ b/test/montos.test.js
@@ -307,9 +307,12 @@ async function testMontoFormLayoutCamposYAcciones() {
     const fieldsRow = formEl.firstElementChild;
     const actionRow = fieldsRow.nextElementSibling;
     const fields = [...fieldsRow.children];
+    const fieldNames = fields.map(field => field.dataset.fieldName);
 
     assert(fieldsRow.classList.contains('row'), 'La primera fila debe contener los campos');
-    assert(fields.map(field => field.dataset.fieldName).join(',') === 'monto,moneda,vencimiento', 'Los campos deben ordenarse Monto, Moneda, Vencimiento');
+    assert(fieldNames[0] === 'monto', 'El primer campo debe ser Monto');
+    assert(fieldNames[1] === 'moneda', 'El segundo campo debe ser Moneda');
+    assert(fieldNames[2] === 'vencimiento', 'El tercer campo debe ser Vencimiento');
     assert(fields.every(field => field.classList.contains('col-12')), 'Cada campo debe ocupar ancho completo en mobile');
     assert(fields.every(field => field.classList.contains('col-md-4')), 'Los tres campos deben compartir la fila en desktop');
     assert(actionRow.classList.contains('justify-content-end'), 'La fila de acciones debe alinearse a la derecha');

--- a/test/montos.test.js
+++ b/test/montos.test.js
@@ -296,6 +296,30 @@ async function testMontosFormsUxValidacionConsistente() {
     await cleanup();
 }
 
+async function testMontoFormLayoutCamposYAcciones() {
+    console.log('  UC4c: MontoForm separa campos y acciones en dos filas');
+    await cleanup();
+
+    const montoForm = document.createElement('monto-form');
+    document.body.appendChild(montoForm);
+
+    const formEl = montoForm.querySelector('app-form form');
+    const fieldsRow = formEl.firstElementChild;
+    const actionRow = fieldsRow.nextElementSibling;
+    const fields = [...fieldsRow.children];
+
+    assert(fieldsRow.classList.contains('row'), 'La primera fila debe contener los campos');
+    assert(fields.map(field => field.dataset.fieldName).join(',') === 'monto,moneda,vencimiento', 'Los campos deben ordenarse Monto, Moneda, Vencimiento');
+    assert(fields.every(field => field.classList.contains('col-12')), 'Cada campo debe ocupar ancho completo en mobile');
+    assert(fields.every(field => field.classList.contains('col-md-4')), 'Los tres campos deben compartir la fila en desktop');
+    assert(actionRow.classList.contains('justify-content-end'), 'La fila de acciones debe alinearse a la derecha');
+    assert(actionRow.querySelector('#cancelBtn') !== null, 'La fila de acciones debe incluir Cancelar');
+    assert(actionRow.querySelector('button[type="submit"]') !== null, 'La fila de acciones debe incluir Guardar');
+
+    document.body.removeChild(montoForm);
+    await cleanup();
+}
+
 // ===================================================================
 // UC5: Flujo completo — crear deuda con montos via DebtForm, listar
 // por mes, marcar pagado, verificar totales, eliminar monto individual
@@ -430,6 +454,7 @@ export const tests = [
     testDuplicarMontoDesdeModal,
     testCancelarFormularios,
     testMontosFormsUxValidacionConsistente,
+    testMontoFormLayoutCamposYAcciones,
     testFlujoCompletoMontosViaDebtForm,
     testTotalesMixtosPorMoneda
 ];


### PR DESCRIPTION
This pull request refactors the "Agregar monto" workflow in `DebtForm` to use a reusable `MontoForm` web component with clearer UI states, improved inline validation UX, and updated tests.

The main changes are grouped as follows:

**DebtForm Amount Section States:**

* The `Montos` section now has explicit UI states: `idle`, `creating`, and `editing`.
* In `idle`, the table/list of added montos and the `Agregar monto` button are shown.
* In `creating` or `editing`, the table/list and `Agregar monto` button are hidden, and only the monto form is shown.
* The same inline form container is now reused for both create and edit flows, with contextual title:
  * `Nuevo monto` when creating.
  * `Editar monto` when editing.

**MontoForm Improvements:**

* `MontoForm` keeps `inline` layout support for horizontal integration.
* Added compact validation mode for the DebtForm inline flow:
  * invalid fields are still marked/accessibility state is preserved.
  * long per-field messages are hidden in this specific flow.
  * a short general message is shown below the row:  
    `Completá monto, moneda y vencimiento para agregar el monto.`
  * short per-field messages are defined for monto/moneda/vencimiento in compact mode.
* Save/cancel events remain standardized, including cancel propagation isolation.

**AppForm Accessibility &amp; Validation Feedback:**

* Per-field `.invalid-feedback` and ARIA validation behavior remain in place across forms (`aria-invalid`, `aria-describedby`, and cleanup behavior).

**UI Consistency:**

* Maintains the prior inline form layout consistency and related alignment improvements.

**Test Coverage:**

* Updated tests for `DebtForm` to validate:
  * new amount section state behavior (`idle | creating | editing`)
  * visibility toggling of table/button/form by state
  * shared create/edit form behavior with contextual titles
  * compact general validation message behavior in inline monto flow
* Existing validation/accessibility and modal-cancel isolation coverage remains aligned with the refactor.

These changes improve the monto editing/creation UX by avoiding grid breakage from long inline errors, while keeping validation accessibility and reusable form logic.