### PR TITLE
Mejora resumen global financiero en Home

### DIFF
--- a/src/features/stats/components/StatsCard.js
+++ b/src/features/stats/components/StatsCard.js
@@ -2,15 +2,20 @@
 // Utiliza clases Bootstrap para las tarjetas de estadísticas
 import { KPI_CURRENCY } from '../../../shared/config/monedas.js';
 
-export default function StatsCard({ title = '', icon = '', items = [], color = 'secondary' } = {}) {
+export default function StatsCard({ title = '', icon = '', items = [], color = 'secondary', meta = '', size = 'default', emphasis = 'default' } = {}) {
+  const isMuted = emphasis === 'muted';
+  const isCompact = size === 'compact';
+
   const card = document.createElement('div');
-  card.className = `card h-100 rounded-4 shadow-sm border border-2 border-${color}`;
+  card.className = isMuted
+    ? 'card h-100 rounded-4 border border-secondary-subtle bg-light'
+    : `card h-100 rounded-4 shadow-sm border border-2 border-${color}`;
 
   const body = document.createElement('div');
-  body.className = 'card-body d-flex flex-column justify-content-between gap-2 p-3';
+  body.className = `card-body d-flex flex-column justify-content-between ${isCompact ? 'gap-1 p-2' : 'gap-2 p-3'}`;
 
   const titleEl = document.createElement('div');
-  titleEl.className = `d-flex align-items-center gap-2 fw-semibold text-uppercase small text-${color}`;
+  titleEl.className = `d-flex align-items-center gap-2 fw-semibold text-uppercase small ${isMuted ? 'text-secondary' : `text-${color}`}`;
   if (icon) {
     const iconEl = document.createElement('i');
     iconEl.className = `bi ${icon}`;
@@ -25,9 +30,9 @@ export default function StatsCard({ title = '', icon = '', items = [], color = '
   if (items.length > 0) {
     const mainItem = items.find(i => i.currency === KPI_CURRENCY) || items[0];
     const arsEl = document.createElement('h6');
-    arsEl.className = `d-flex align-items-center gap-2 text-nowrap fw-bold text-${color} lh-sm mb-0`;
+    arsEl.className = `d-flex align-items-center gap-2 text-nowrap fw-bold ${isMuted ? 'text-body' : `text-${color}`} lh-sm mb-0`;
     const arsBadge = document.createElement('span');
-    arsBadge.className = `badge small bg-${color}`;
+    arsBadge.className = isMuted ? 'badge small text-bg-light border text-secondary' : `badge small bg-${color}`;
     arsBadge.textContent = mainItem.currency;
     arsEl.appendChild(document.createTextNode(mainItem.value));
     arsEl.appendChild(arsBadge);
@@ -35,6 +40,14 @@ export default function StatsCard({ title = '', icon = '', items = [], color = '
   }
 
   body.appendChild(valuesEl);
+
+  if (meta) {
+    const metaEl = document.createElement('div');
+    metaEl.className = 'small text-body-secondary lh-sm';
+    metaEl.textContent = meta;
+    body.appendChild(metaEl);
+  }
+
   card.appendChild(body);
 
   return card;

--- a/src/features/stats/components/StatsIndicators.js
+++ b/src/features/stats/components/StatsIndicators.js
@@ -1,6 +1,6 @@
 // src/components/StatsIndicators.js
 import StatsCard from './StatsCard.js';
-import { getMonthlySummary } from '../statsService.js';
+import { getMonthlySummary, getGlobalPaymentSummary } from '../statsService.js';
 import { addValue } from '../utils/formatCurrency.js';
 import { getSelectedMonth } from '../../../shared/MonthFilter.js';
 
@@ -11,7 +11,95 @@ let _monthHandler = null;
 let _dataChangedHandler = null;
 const DATA_CHANGE_EVENTS = ['data-imported', 'ingreso:added', 'deuda:saved', 'deuda:updated', 'deuda:deleted'];
 
-export default function StatsIndicators({ mes } = {}) {
+function countLabel(count, singular, plural) {
+  const safeCount = Number(count) || 0;
+  return `${safeCount} ${safeCount === 1 ? singular : plural}`;
+}
+
+function renderGlobalSummary(summary) {
+  const section = document.createElement('section');
+  section.className = 'card border-0 bg-body-tertiary rounded-4 shadow-sm mt-2';
+  section.setAttribute('aria-labelledby', 'global-summary-title');
+
+  const body = document.createElement('div');
+  body.className = 'card-body p-2 p-sm-3';
+
+  const header = document.createElement('div');
+  header.className = 'd-flex align-items-start justify-content-between gap-2 mb-2';
+
+  const titleWrapper = document.createElement('div');
+
+  const title = document.createElement('h2');
+  title.id = 'global-summary-title';
+  title.className = 'h6 fw-bold mb-0';
+  title.textContent = 'Situación total';
+  titleWrapper.appendChild(title);
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'small text-body-secondary mb-0';
+  subtitle.textContent = 'Resumen global de todos los períodos';
+  titleWrapper.appendChild(subtitle);
+  header.appendChild(titleWrapper);
+
+  const icon = document.createElement('i');
+  icon.className = 'bi bi-layers text-secondary small';
+  icon.setAttribute('aria-hidden', 'true');
+  header.appendChild(icon);
+  body.appendChild(header);
+
+  const row = document.createElement('div');
+  row.className = 'row g-2 align-items-stretch';
+
+  const cards = [
+    {
+      colClass: 'col-6 col-md-4',
+      props: {
+        title: 'Vencido',
+        icon: 'bi-exclamation-triangle',
+        items: addValue(summary.byCurrency.overdue),
+        color: 'danger',
+        meta: countLabel(summary.counts.overdue, 'vencido', 'vencidos'),
+        size: 'compact'
+      }
+    },
+    {
+      colClass: 'col-6 col-md-4',
+      props: {
+        title: 'Próximos a pagar',
+        icon: 'bi-calendar-event',
+        items: addValue(summary.byCurrency.upcoming),
+        color: 'warning',
+        meta: countLabel(summary.counts.upcoming, 'próximo', 'próximos'),
+        size: 'compact'
+      }
+    },
+    {
+      colClass: 'col-12 col-md-4',
+      props: {
+        title: 'Total por pagar',
+        icon: 'bi-receipt',
+        items: addValue(summary.byCurrency.totalDue),
+        color: 'secondary',
+        meta: countLabel(summary.counts.totalDue, 'pago pendiente', 'pagos pendientes'),
+        size: 'compact',
+        emphasis: 'muted'
+      }
+    }
+  ];
+
+  for (const card of cards) {
+    const col = document.createElement('div');
+    col.className = card.colClass;
+    col.appendChild(StatsCard(card.props));
+    row.appendChild(col);
+  }
+
+  body.appendChild(row);
+  section.appendChild(body);
+  return section;
+}
+
+export default function StatsIndicators({ mes, showGlobalSummary = false } = {}) {
   const container = document.createElement('div');
   container.className = 'mb-4';
   container.setAttribute('data-tour-step', 'indicadores');
@@ -26,6 +114,7 @@ export default function StatsIndicators({ mes } = {}) {
 
     try {
       const summary = await getMonthlySummary(periodo);
+      const globalSummary = showGlobalSummary ? await getGlobalPaymentSummary() : null;
       container.innerHTML = '';
 
       const row = document.createElement('div');
@@ -46,6 +135,10 @@ export default function StatsIndicators({ mes } = {}) {
       }
 
       container.appendChild(row);
+
+      if (globalSummary) {
+        container.appendChild(renderGlobalSummary(globalSummary));
+      }
     } catch (err) {
       container.innerHTML = '';
       const errEl = document.createElement('div');

--- a/src/features/stats/statsService.js
+++ b/src/features/stats/statsService.js
@@ -45,3 +45,54 @@ export async function getMonthlySummary(mes) {
     }
   };
 }
+
+function addAmount(target, currency, amount) {
+  target[currency] = (target[currency] || 0) + (Number(amount) || 0);
+}
+
+function isOverduePayment(payment, todayISO) {
+  const dueDate = typeof payment.vencimiento === 'string' ? payment.vencimiento.slice(0, 10) : '';
+  return Boolean(dueDate && dueDate < todayISO);
+}
+
+export function summarizeGlobalPayments(montos = [], todayISO = new Date().toISOString().slice(0, 10)) {
+  const totalDue = {};
+  const overdue = {};
+  const upcoming = {};
+  const counts = {
+    totalDue: 0,
+    overdue: 0,
+    upcoming: 0
+  };
+
+  (montos || []).forEach((payment) => {
+    if (!payment || payment.pagado) return;
+
+    counts.totalDue += 1;
+    addAmount(totalDue, payment.moneda, payment.monto);
+
+    if (isOverduePayment(payment, todayISO)) {
+      counts.overdue += 1;
+      addAmount(overdue, payment.moneda, payment.monto);
+      return;
+    }
+
+    counts.upcoming += 1;
+    addAmount(upcoming, payment.moneda, payment.monto);
+  });
+
+  return {
+    byCurrency: {
+      totalDue,
+      overdue,
+      upcoming
+    },
+    counts
+  };
+}
+
+export async function getGlobalPaymentSummary() {
+  const { listMontos } = await import('../montos/montoRepository.js');
+  const montos = await listMontos();
+  return summarizeGlobalPayments(montos);
+}

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -9,7 +9,7 @@ export default function Home() {
 
   import('../features/stats/components/StatsIndicators.js')
     .then(({ default: StatsIndicators }) => {
-      statsSlot.appendChild(StatsIndicators());
+      statsSlot.appendChild(StatsIndicators({ showGlobalSummary: true }));
     })
     .catch(() => {
       statsSlot.innerHTML = '<p class="text-muted small">No se pudieron cargar los indicadores.</p>';

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -4,6 +4,7 @@ import { assert } from './setup.js';
 import StatsCard from '../src/features/stats/components/StatsCard.js';
 import StatsIndicators from '../src/features/stats/components/StatsIndicators.js';
 import { addValue, compactFormat } from '../src/features/stats/utils/formatCurrency.js';
+import { summarizeGlobalPayments } from '../src/features/stats/statsService.js';
 
 // ===================================================================
 // UC1: StatsCard renders with correct Bootstrap classes
@@ -177,6 +178,58 @@ async function testStatsIndicatorsCardOrder() {
     );
 }
 
+
+// ===================================================================
+// UC13: summarizeGlobalPayments separates overdue, upcoming, and total
+// ===================================================================
+async function testSummarizeGlobalPaymentsBucketsAndCounts() {
+    console.log('  UC13: summarizeGlobalPayments separa vencidos, próximos y total');
+
+    const summary = summarizeGlobalPayments([
+        { monto: 1000, moneda: 'ARS', vencimiento: '2026-01-10', pagado: false },
+        { monto: 2000, moneda: 'ARS', vencimiento: '2026-07-10', pagado: false },
+        { monto: 50, moneda: 'USD', vencimiento: '2026-08-01', pagado: false },
+        { monto: 9999, moneda: 'ARS', vencimiento: '2026-01-01', pagado: true }
+    ], '2026-06-06');
+
+    assert(summary.byCurrency.overdue.ARS === 1000, 'vencido debe sumar solo pagos impagos anteriores a hoy');
+    assert(summary.byCurrency.upcoming.ARS === 2000, 'próximos debe sumar pagos impagos no vencidos en ARS');
+    assert(summary.byCurrency.upcoming.USD === 50, 'próximos debe sumar pagos impagos no vencidos en USD');
+    assert(summary.byCurrency.totalDue.ARS === 3000, 'total por pagar debe consolidar vencidos y próximos');
+    assert(summary.counts.overdue === 1, 'debe contar 1 vencido');
+    assert(summary.counts.upcoming === 2, 'debe contar 2 próximos');
+    assert(summary.counts.totalDue === 3, 'debe contar 3 pagos pendientes');
+}
+
+// ===================================================================
+// UC14: StatsIndicators global summary is opt-in and visually separated
+// ===================================================================
+async function testStatsIndicatorsGlobalSummaryOptIn() {
+    console.log('  UC14: StatsIndicators muestra resumen global solo si showGlobalSummary=true');
+
+    const withoutGlobal = StatsIndicators({ mes: '2030-01' });
+    await new Promise(resolve => setTimeout(resolve, 50));
+    assert(!withoutGlobal.textContent.includes('Situación total'), 'sin showGlobalSummary no debe mostrar situación total');
+
+    const withGlobal = StatsIndicators({ mes: '2030-01', showGlobalSummary: true });
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    assert(withGlobal.textContent.includes('Situación total'), 'con showGlobalSummary debe mostrar situación total');
+    assert(withGlobal.textContent.includes('Resumen global de todos los períodos'), 'copy debe aclarar que incluye todos los períodos');
+    assert(withGlobal.textContent.includes('Vencido'), 'resumen global debe priorizar vencido');
+    assert(withGlobal.textContent.includes('Próximos a pagar'), 'resumen global debe priorizar próximos a pagar');
+    assert(withGlobal.textContent.includes('Total por pagar'), 'resumen global debe mantener total por pagar');
+
+    const globalSection = withGlobal.querySelector('section[aria-labelledby="global-summary-title"]');
+    assert(globalSection !== null, 'resumen global debe renderizarse como sección separada');
+    assert(globalSection.classList.contains('bg-body-tertiary'), 'resumen global debe tener contenedor visual separado y liviano');
+
+    const totalCard = [...globalSection.querySelectorAll('.card')].find(card => card.textContent.includes('Total por pagar'));
+    assert(totalCard !== undefined, 'debe existir la tarjeta Total por pagar');
+    assert(totalCard.classList.contains('border-secondary-subtle'), 'Total por pagar debe usar estilo neutro');
+    assert(!totalCard.classList.contains('border-success'), 'Total por pagar no debe usar color positivo');
+}
+
 export const tests = [
     testStatsCardBootstrapClasses,
     testStatsCardItemClasses,
@@ -190,4 +243,6 @@ export const tests = [
     testCompactFormatSmall,
     testCompactFormatNull,
     testStatsIndicatorsCardOrder,
+    testSummarizeGlobalPaymentsBucketsAndCounts,
+    testStatsIndicatorsGlobalSummaryOptIn,
 ];


### PR DESCRIPTION
### Motivation
- Añadir una segunda capa de lectura global en Home que sea más clara y accionable sin mezclarla con el resumen mensual existente.
- Priorizar métricas que impulsan decisiones (`Vencido`, `Pendiente futuro` / `Próximos a pagar`) y hacer que `Total por pagar` sea una métrica consolidada y visualmente neutra.

### Description
- Mantengo intacta la lógica y render del resumen mensual y hago que el resumen global sea una segunda capa opt-in a través de `showGlobalSummary` (activado en `Home`); no rompe el resumen mensual. (`src/pages/Home.js`, `src/features/stats/components/StatsIndicators.js`).
- Nuevo bloque visual `Situación total` con microcopy más explícito `Resumen global de todos los períodos` y estructura Bootstrap compacta (`p-2`, `g-2`, `col-6/col-12`) para reducir altura en mobile. (`src/features/stats/components/StatsIndicators.js`).
- Extensión de `StatsCard` con opciones reutilizables: `meta`, `size: 'compact'` y `emphasis: 'muted'` para permitir tarjetas más compactas y una versión sobria/neutra para `Total por pagar`. (`src/features/stats/components/StatsCard.js`).
- Lógica de resumen global que separa montos impagos en `overdue` (vencido), `upcoming` (próximos) y `totalDue` además de devolver conteos por bucket; y `getGlobalPaymentSummary()` que agrega esta capa desde los montos disponibles. (no altera el cálculo mensual). (`src/features/stats/statsService.js`).
- Visual: prioricé `Vencido` y `Próximos a pagar` como tarjetas compactas y con color de énfasis, y dejé `Total por pagar` en estilo neutro/compacto para que no compita visualmente.
- Tests: se agregaron pruebas unitarias para `summarizeGlobalPayments` y pruebas de integración que verifican que el resumen global es opt-in, está separado y usa el nuevo copy/estilos. (`test/stats.test.js`).

### Testing
- Ejecuté `npm test` y todos los tests pasaron: `1119 passed, 0 failed`.
- Ejecuté `npm run lint` y no se detectaron errores de lint en los archivos modificados.
- Intenté generar capturas con Playwright pero la ejecución quedó bloqueada por políticas de red (403), por lo que no se incluyeron capturas visuales automáticas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24616c6aec8323aba7fbbcfbb219d4)