### PR TITLE
Automate service worker cache versioning

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // Estrategia: precache de assets públicos estables + runtime cache para el resto.
 // Los bundles de Vite quedan fuera del precache porque usan nombres hasheados.
 
-const CACHE_VERSION = 'nivva-v3';
+const CACHE_VERSION = '__NIVVA_CACHE_VERSION__';
 
 const APP_SHELL = [
     './',

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,28 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 
+function serviceWorkerCacheVersionPlugin() {
+    return {
+        name: 'nivva-service-worker-cache-version',
+        apply: 'build',
+        closeBundle() {
+            const buildTimestamp = process.env.BUILD_TIMESTAMP || new Date().toISOString();
+            const cacheVersion = `nivva-${buildTimestamp.replace(/[^0-9]/g, '')}`;
+            const sourcePath = resolve('public/sw.js');
+            const outputPath = resolve('dist/sw.js');
+            const source = readFileSync(sourcePath, 'utf8');
+
+            writeFileSync(
+                outputPath,
+                source.replace('__NIVVA_CACHE_VERSION__', cacheVersion)
+            );
+        }
+    };
+}
+
 export default defineConfig({
+    plugins: [serviceWorkerCacheVersionPlugin()],
     css: {
         preprocessorOptions: {
             scss: {


### PR DESCRIPTION
### Motivation

- Evitar el mantenimiento manual de la versión del caché del Service Worker y forzar actualización de clientes cuando hay un nuevo build. 
- Usar un valor determinista por build (o `BUILD_TIMESTAMP`) en lugar de incrementar manualmente `nivva-vX`.

### Description

- Replaced the hard-coded cache name in `public/sw.js` with the placeholder `__NIVVA_CACHE_VERSION__` so the file can be stamped at build time.
- Added a small Vite build plugin in `vite.config.js` that runs on `closeBundle` and computes `cacheVersion` from `BUILD_TIMESTAMP` or the current date, sanitized to digits, producing names like `nivva-YYYYMMDD...`.
- The plugin writes a stamped `dist/sw.js` by reading `public/sw.js` and replacing `__NIVVA_CACHE_VERSION__` with the computed `cacheVersion` during the production build.

### Testing

- Ran `npm test`, which completed successfully (`990 passed, 0 failed`).
- Ran `npm run build`, which completed successfully and produced `dist/` assets.
- Ran `npm run lint`, which returned no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30a35f44f483238d0ff4a3849fb3a8)