### PR TITLE
Mejorar encabezado móvil y accesibilidad del selector de mes

### DIFF
--- a/src/layout/MonthSelector.js
+++ b/src/layout/MonthSelector.js
@@ -22,7 +22,7 @@ export class MonthSelector extends HTMLElement {
 
     _render() {
         const group = document.createElement('div');
-        group.className = 'input-group input-group-sm mb-3';
+        group.className = 'input-group input-group-lg mb-3';
         group.dataset.tourStep = 'navegacion-mes';
 
         const icon = document.createElement('span');
@@ -31,7 +31,7 @@ export class MonthSelector extends HTMLElement {
 
         const prev = document.createElement('button');
         prev.id = 'ms-prev';
-        prev.className = 'btn btn-outline-secondary';
+        prev.className = 'btn btn-primary';
         prev.type = 'button';
         prev.title = 'Mes anterior';
         prev.setAttribute('aria-label', 'Mes anterior');
@@ -46,7 +46,7 @@ export class MonthSelector extends HTMLElement {
 
         const next = document.createElement('button');
         next.id = 'ms-next';
-        next.className = 'btn btn-outline-secondary';
+        next.className = 'btn btn-primary';
         next.type = 'button';
         next.title = 'Mes siguiente';
         next.setAttribute('aria-label', 'Mes siguiente');

--- a/src/layout/MonthSelector.js
+++ b/src/layout/MonthSelector.js
@@ -22,12 +22,12 @@ export class MonthSelector extends HTMLElement {
 
     _render() {
         const group = document.createElement('div');
-        group.className = 'input-group input-group-sm';
+        group.className = 'btn-group btn-group-sm';
         group.dataset.tourStep = 'navegacion-mes';
 
         const prev = document.createElement('button');
         prev.id = 'ms-prev';
-        prev.className = 'btn btn-outline-secondary';
+        prev.className = 'btn btn-outline-secondary px-3';
         prev.type = 'button';
         prev.title = 'Mes anterior';
         prev.setAttribute('aria-label', 'Mes anterior');
@@ -43,15 +43,15 @@ export class MonthSelector extends HTMLElement {
 
         const next = document.createElement('button');
         next.id = 'ms-next';
-        next.className = 'btn btn-outline-secondary';
+        next.className = 'btn btn-outline-secondary px-3';
         next.type = 'button';
         next.title = 'Mes siguiente';
         next.setAttribute('aria-label', 'Mes siguiente');
         next.textContent = '›';
 
         group.appendChild(prev);
-        group.appendChild(input);
         group.appendChild(next);
+        group.appendChild(input);
 
         this.innerHTML = '';
         this.appendChild(group);

--- a/src/layout/MonthSelector.js
+++ b/src/layout/MonthSelector.js
@@ -1,5 +1,5 @@
 // src/layout/MonthSelector.js
-// Compact global month selector web component — Bootstrap Input Group with input[type=month]
+// Compact global month selector web component — Bootstrap Input Group with input[type=date]
 import {
     getSelectedMonth,
     setSelectedMonth,
@@ -35,10 +35,10 @@ export class MonthSelector extends HTMLElement {
 
         const input = document.createElement('input');
         input.id = 'ms-input';
-        input.type = 'month';
-        input.className = 'form-control text-center';
-        input.value = getSelectedMonth();
-        input.setAttribute('aria-label', 'Seleccionar mes');
+        input.type = 'date';
+        input.className = 'form-control text-center flex-grow-0 w-auto';
+        input.value = `${getSelectedMonth()}-01`;
+        input.setAttribute('aria-label', 'Seleccionar fecha del mes');
 
         const next = document.createElement('button');
         next.id = 'ms-next';
@@ -70,10 +70,11 @@ export class MonthSelector extends HTMLElement {
         });
         this.querySelector('#ms-input').addEventListener('change', (e) => {
             if (e.target.value) {
-                setSelectedMonth(e.target.value);
+                const selectedMonth = e.target.value.slice(0, 7);
+                setSelectedMonth(selectedMonth);
                 trackEvent('monthly_navigation_used', {
                     direction: 'direct_select',
-                    month: e.target.value
+                    month: selectedMonth
                 });
             }
         });
@@ -81,7 +82,8 @@ export class MonthSelector extends HTMLElement {
 
     _syncInput(month) {
         const input = this.querySelector('#ms-input');
-        if (input && input.value !== month) input.value = month;
+        const dateValue = `${month}-01`;
+        if (input && input.value !== dateValue) input.value = dateValue;
     }
 }
 

--- a/src/layout/MonthSelector.js
+++ b/src/layout/MonthSelector.js
@@ -1,5 +1,5 @@
 // src/layout/MonthSelector.js
-// Compact global month selector web component — Bootstrap Input Group with input[type=date]
+// Compact global month selector web component — Bootstrap Input Group with input[type=month]
 import {
     getSelectedMonth,
     setSelectedMonth,
@@ -22,12 +22,16 @@ export class MonthSelector extends HTMLElement {
 
     _render() {
         const group = document.createElement('div');
-        group.className = 'd-inline-flex align-items-center gap-1';
+        group.className = 'input-group input-group-sm mb-3';
         group.dataset.tourStep = 'navegacion-mes';
+
+        const icon = document.createElement('span');
+        icon.className = 'input-group-text';
+        icon.innerHTML = '<i class="bi bi-calendar-event" aria-hidden="true"></i>';
 
         const prev = document.createElement('button');
         prev.id = 'ms-prev';
-        prev.className = 'btn btn-sm btn-outline-secondary rounded-circle d-inline-flex align-items-center justify-content-center';
+        prev.className = 'btn btn-outline-secondary';
         prev.type = 'button';
         prev.title = 'Mes anterior';
         prev.setAttribute('aria-label', 'Mes anterior');
@@ -35,20 +39,20 @@ export class MonthSelector extends HTMLElement {
 
         const input = document.createElement('input');
         input.id = 'ms-input';
-        input.type = 'date';
-        input.className = 'visually-hidden-focusable';
-        input.value = `${getSelectedMonth()}-01`;
-        input.setAttribute('aria-label', 'Seleccionar fecha del mes');
-        input.setAttribute('title', 'Seleccionar fecha del mes');
+        input.type = 'month';
+        input.className = 'form-control';
+        input.value = getSelectedMonth();
+        input.setAttribute('aria-label', 'Seleccionar mes');
 
         const next = document.createElement('button');
         next.id = 'ms-next';
-        next.className = 'btn btn-sm btn-outline-secondary rounded-circle d-inline-flex align-items-center justify-content-center';
+        next.className = 'btn btn-outline-secondary';
         next.type = 'button';
         next.title = 'Mes siguiente';
         next.setAttribute('aria-label', 'Mes siguiente');
         next.textContent = '›';
 
+        group.appendChild(icon);
         group.appendChild(prev);
         group.appendChild(next);
         group.appendChild(input);
@@ -71,11 +75,10 @@ export class MonthSelector extends HTMLElement {
         });
         this.querySelector('#ms-input').addEventListener('change', (e) => {
             if (e.target.value) {
-                const selectedMonth = e.target.value.slice(0, 7);
-                setSelectedMonth(selectedMonth);
+                setSelectedMonth(e.target.value);
                 trackEvent('monthly_navigation_used', {
                     direction: 'direct_select',
-                    month: selectedMonth
+                    month: e.target.value
                 });
             }
         });
@@ -83,8 +86,7 @@ export class MonthSelector extends HTMLElement {
 
     _syncInput(month) {
         const input = this.querySelector('#ms-input');
-        const dateValue = `${month}-01`;
-        if (input && input.value !== dateValue) input.value = dateValue;
+        if (input && input.value !== month) input.value = month;
     }
 }
 

--- a/src/layout/MonthSelector.js
+++ b/src/layout/MonthSelector.js
@@ -22,12 +22,12 @@ export class MonthSelector extends HTMLElement {
 
     _render() {
         const group = document.createElement('div');
-        group.className = 'btn-group btn-group-sm';
+        group.className = 'd-inline-flex align-items-center gap-1';
         group.dataset.tourStep = 'navegacion-mes';
 
         const prev = document.createElement('button');
         prev.id = 'ms-prev';
-        prev.className = 'btn btn-outline-secondary px-3';
+        prev.className = 'btn btn-sm btn-outline-secondary rounded-circle d-inline-flex align-items-center justify-content-center';
         prev.type = 'button';
         prev.title = 'Mes anterior';
         prev.setAttribute('aria-label', 'Mes anterior');
@@ -43,7 +43,7 @@ export class MonthSelector extends HTMLElement {
 
         const next = document.createElement('button');
         next.id = 'ms-next';
-        next.className = 'btn btn-outline-secondary px-3';
+        next.className = 'btn btn-sm btn-outline-secondary rounded-circle d-inline-flex align-items-center justify-content-center';
         next.type = 'button';
         next.title = 'Mes siguiente';
         next.setAttribute('aria-label', 'Mes siguiente');

--- a/src/layout/MonthSelector.js
+++ b/src/layout/MonthSelector.js
@@ -36,9 +36,10 @@ export class MonthSelector extends HTMLElement {
         const input = document.createElement('input');
         input.id = 'ms-input';
         input.type = 'date';
-        input.className = 'form-control text-center flex-grow-0 w-auto';
+        input.className = 'visually-hidden-focusable';
         input.value = `${getSelectedMonth()}-01`;
         input.setAttribute('aria-label', 'Seleccionar fecha del mes');
+        input.setAttribute('title', 'Seleccionar fecha del mes');
 
         const next = document.createElement('button');
         next.id = 'ms-next';

--- a/src/layout/ResumenHeader.js
+++ b/src/layout/ResumenHeader.js
@@ -2,12 +2,6 @@
 // Global page header: page title + global month selector + subtitle
 import './MonthSelector.js';
 import { DEFAULT_SUBTITLE } from './navConfig.js';
-import { formatMonthLabel, getSelectedMonth } from '../shared/MonthFilter.js';
-
-function formatFeaturedMonth(month) {
-    const label = formatMonthLabel(month);
-    return `${label.charAt(0).toUpperCase()}${label.slice(1)}`;
-}
 
 export default function ResumenHeader({ title = 'Tu panorama financiero', subtitle = DEFAULT_SUBTITLE } = {}) {
     const el = document.createElement('div');
@@ -19,23 +13,11 @@ export default function ResumenHeader({ title = 'Tu panorama financiero', subtit
     titleEl.id = 'resumen-header-title';
     titleEl.textContent = title;
 
-    const periodIcon = document.createElement('i');
-    periodIcon.className = 'bi bi-calendar-event h5 mb-0';
-    periodIcon.setAttribute('aria-hidden', 'true');
-
-    const monthLabel = document.createElement('div');
-    monthLabel.className = 'h5 fw-semibold mb-0';
-    monthLabel.id = 'resumen-header-month';
-    monthLabel.textContent = formatFeaturedMonth(getSelectedMonth());
-
     const monthSelector = document.createElement('month-selector');
-    monthSelector.classList.add('flex-shrink-0');
 
     const topRow = document.createElement('div');
-    topRow.className = 'd-inline-flex align-items-center gap-2 mb-1';
-    topRow.appendChild(periodIcon);
+    topRow.className = 'mb-1';
     topRow.appendChild(monthSelector);
-    topRow.appendChild(monthLabel);
 
     const subtitleEl = document.createElement('p');
     subtitleEl.className = 'text-body-secondary mb-0';
@@ -46,11 +28,6 @@ export default function ResumenHeader({ title = 'Tu panorama financiero', subtit
     el.appendChild(titleEl);
     el.appendChild(subtitleEl);
 
-    el._onUiMonth = (event) => {
-        const month = event.detail?.mes || getSelectedMonth();
-        monthLabel.textContent = formatFeaturedMonth(month);
-    };
-    window.addEventListener('ui:month', el._onUiMonth);
 
     el.update = ({ title: newTitle, subtitle: newSubtitle, hideMonthSelector } = {}) => {
         if (newTitle !== undefined) {
@@ -60,14 +37,8 @@ export default function ResumenHeader({ title = 'Tu panorama financiero', subtit
             el.querySelector('#resumen-header-subtitle').textContent = newSubtitle;
         }
         if (hideMonthSelector !== undefined) {
-            periodIcon.classList.toggle('d-none', !!hideMonthSelector);
             monthSelector.classList.toggle('d-none', !!hideMonthSelector);
-            monthLabel.classList.toggle('d-none', !!hideMonthSelector);
         }
-    };
-
-    el.destroy = () => {
-        window.removeEventListener('ui:month', el._onUiMonth);
     };
 
     return el;

--- a/src/layout/ResumenHeader.js
+++ b/src/layout/ResumenHeader.js
@@ -2,22 +2,29 @@
 // Global page header: page title + global month selector + subtitle
 import './MonthSelector.js';
 import { DEFAULT_SUBTITLE } from './navConfig.js';
+import { formatMonthLabel, getSelectedMonth } from '../shared/MonthFilter.js';
 
-export default function ResumenHeader({ title = 'Panorama financiero', subtitle = DEFAULT_SUBTITLE } = {}) {
+export default function ResumenHeader({ title = 'Tu panorama financiero', subtitle = DEFAULT_SUBTITLE } = {}) {
     const el = document.createElement('div');
     el.className = 'mb-3';
     el.id = 'resumen-header';
 
     const titleEl = document.createElement('h1');
-    titleEl.className = 'h3 fw-bold mb-0';
+    titleEl.className = 'h3 fw-bold mb-1';
     titleEl.id = 'resumen-header-title';
     titleEl.textContent = title;
 
+    const monthLabel = document.createElement('div');
+    monthLabel.className = 'h4 fw-semibold mb-0 text-capitalize d-inline-flex align-items-center gap-2';
+    monthLabel.id = 'resumen-header-month';
+    monthLabel.innerHTML = `<i class="bi bi-calendar3" aria-hidden="true"></i><span>${formatMonthLabel(getSelectedMonth())}</span>`;
+
     const monthSelector = document.createElement('month-selector');
+    monthSelector.classList.add('flex-shrink-0');
 
     const topRow = document.createElement('div');
-    topRow.className = 'd-flex justify-content-between align-items-center gap-3 mb-1';
-    topRow.appendChild(titleEl);
+    topRow.className = 'd-flex justify-content-between align-items-center gap-2 flex-wrap mb-2';
+    topRow.appendChild(monthLabel);
     topRow.appendChild(monthSelector);
 
     const subtitleEl = document.createElement('p');
@@ -26,7 +33,14 @@ export default function ResumenHeader({ title = 'Panorama financiero', subtitle 
     subtitleEl.textContent = subtitle;
 
     el.appendChild(topRow);
+    el.appendChild(titleEl);
     el.appendChild(subtitleEl);
+
+    el._onUiMonth = (event) => {
+        const month = event.detail?.mes || getSelectedMonth();
+        monthLabel.querySelector('span').textContent = formatMonthLabel(month);
+    };
+    window.addEventListener('ui:month', el._onUiMonth);
 
     el.update = ({ title: newTitle, subtitle: newSubtitle, hideMonthSelector } = {}) => {
         if (newTitle !== undefined) {
@@ -37,7 +51,12 @@ export default function ResumenHeader({ title = 'Panorama financiero', subtitle 
         }
         if (hideMonthSelector !== undefined) {
             monthSelector.classList.toggle('d-none', !!hideMonthSelector);
+            monthLabel.classList.toggle('d-none', !!hideMonthSelector);
         }
+    };
+
+    el.destroy = () => {
+        window.removeEventListener('ui:month', el._onUiMonth);
     };
 
     return el;

--- a/src/layout/ResumenHeader.js
+++ b/src/layout/ResumenHeader.js
@@ -4,6 +4,11 @@ import './MonthSelector.js';
 import { DEFAULT_SUBTITLE } from './navConfig.js';
 import { formatMonthLabel, getSelectedMonth } from '../shared/MonthFilter.js';
 
+function formatFeaturedMonth(month) {
+    const label = formatMonthLabel(month);
+    return `${label.charAt(0).toUpperCase()}${label.slice(1)}`;
+}
+
 export default function ResumenHeader({ title = 'Tu panorama financiero', subtitle = DEFAULT_SUBTITLE } = {}) {
     const el = document.createElement('div');
     el.className = 'mb-3';
@@ -15,15 +20,15 @@ export default function ResumenHeader({ title = 'Tu panorama financiero', subtit
     titleEl.textContent = title;
 
     const monthLabel = document.createElement('div');
-    monthLabel.className = 'h4 fw-semibold mb-0 text-capitalize d-inline-flex align-items-center gap-2';
+    monthLabel.className = 'h5 fw-semibold mb-0 d-inline-flex align-items-center gap-2';
     monthLabel.id = 'resumen-header-month';
-    monthLabel.innerHTML = `<i class="bi bi-calendar3" aria-hidden="true"></i><span>${formatMonthLabel(getSelectedMonth())}</span>`;
+    monthLabel.innerHTML = `<i class="bi bi-calendar-event" aria-hidden="true"></i><span>${formatFeaturedMonth(getSelectedMonth())}</span>`;
 
     const monthSelector = document.createElement('month-selector');
     monthSelector.classList.add('flex-shrink-0');
 
     const topRow = document.createElement('div');
-    topRow.className = 'd-flex justify-content-between align-items-center gap-2 flex-wrap mb-2';
+    topRow.className = 'd-inline-flex align-items-center gap-2 mb-1';
     topRow.appendChild(monthLabel);
     topRow.appendChild(monthSelector);
 
@@ -38,7 +43,7 @@ export default function ResumenHeader({ title = 'Tu panorama financiero', subtit
 
     el._onUiMonth = (event) => {
         const month = event.detail?.mes || getSelectedMonth();
-        monthLabel.querySelector('span').textContent = formatMonthLabel(month);
+        monthLabel.querySelector('span').textContent = formatFeaturedMonth(month);
     };
     window.addEventListener('ui:month', el._onUiMonth);
 

--- a/src/layout/ResumenHeader.js
+++ b/src/layout/ResumenHeader.js
@@ -19,18 +19,23 @@ export default function ResumenHeader({ title = 'Tu panorama financiero', subtit
     titleEl.id = 'resumen-header-title';
     titleEl.textContent = title;
 
+    const periodIcon = document.createElement('i');
+    periodIcon.className = 'bi bi-calendar-event h5 mb-0';
+    periodIcon.setAttribute('aria-hidden', 'true');
+
     const monthLabel = document.createElement('div');
-    monthLabel.className = 'h5 fw-semibold mb-0 d-inline-flex align-items-center gap-2';
+    monthLabel.className = 'h5 fw-semibold mb-0';
     monthLabel.id = 'resumen-header-month';
-    monthLabel.innerHTML = `<i class="bi bi-calendar-event" aria-hidden="true"></i><span>${formatFeaturedMonth(getSelectedMonth())}</span>`;
+    monthLabel.textContent = formatFeaturedMonth(getSelectedMonth());
 
     const monthSelector = document.createElement('month-selector');
     monthSelector.classList.add('flex-shrink-0');
 
     const topRow = document.createElement('div');
     topRow.className = 'd-inline-flex align-items-center gap-2 mb-1';
-    topRow.appendChild(monthLabel);
+    topRow.appendChild(periodIcon);
     topRow.appendChild(monthSelector);
+    topRow.appendChild(monthLabel);
 
     const subtitleEl = document.createElement('p');
     subtitleEl.className = 'text-body-secondary mb-0';
@@ -43,7 +48,7 @@ export default function ResumenHeader({ title = 'Tu panorama financiero', subtit
 
     el._onUiMonth = (event) => {
         const month = event.detail?.mes || getSelectedMonth();
-        monthLabel.querySelector('span').textContent = formatFeaturedMonth(month);
+        monthLabel.textContent = formatFeaturedMonth(month);
     };
     window.addEventListener('ui:month', el._onUiMonth);
 
@@ -55,6 +60,7 @@ export default function ResumenHeader({ title = 'Tu panorama financiero', subtit
             el.querySelector('#resumen-header-subtitle').textContent = newSubtitle;
         }
         if (hideMonthSelector !== undefined) {
+            periodIcon.classList.toggle('d-none', !!hideMonthSelector);
             monthSelector.classList.toggle('d-none', !!hideMonthSelector);
             monthLabel.classList.toggle('d-none', !!hideMonthSelector);
         }

--- a/src/layout/navConfig.js
+++ b/src/layout/navConfig.js
@@ -1,8 +1,8 @@
 // Shared navigation items used by the desktop menu (Menu.js) and mobile bottom navbar (BottomNav.js)
-export const DEFAULT_SUBTITLE = 'Gestioná y visualizá la información del período seleccionado.';
+export const DEFAULT_SUBTITLE = 'Gestioná tus pagos y vencimientos del período.';
 
 export const navItems = [
-  { label: 'Inicio', icon: 'bi-house', path: '/', key: 'inicio', title: 'Panorama financiero', subtitle: DEFAULT_SUBTITLE },
+  { label: 'Inicio', icon: 'bi-house', path: '/', key: 'inicio', title: 'Tu panorama financiero', subtitle: DEFAULT_SUBTITLE },
   { label: 'Ingresos', icon: 'bi-cash-stack', path: '/ingresos', key: 'ingresos', title: 'Ingresos del mes', subtitle: DEFAULT_SUBTITLE },
   { label: 'Deudas', icon: 'bi-wallet2', path: '/gastos', key: 'gastos', title: 'Deudas', subtitle: DEFAULT_SUBTITLE },
 ];

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -196,6 +196,7 @@ export const tests = [
         const input = selector.querySelector('#ms-input');
         assert(input.type === 'date', 'Selector debe mantener un input date accesible');
         assert(input.getAttribute('aria-label') === 'Seleccionar fecha del mes', 'Input date debe tener aria-label');
+        assert(input.classList.contains('visually-hidden-focusable'), 'Input date debe permanecer oculto visualmente hasta recibir foco');
 
         input.value = '2026-07-15';
         input.dispatchEvent(new Event('change'));

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -197,7 +197,10 @@ export const tests = [
 
         const group = selector.querySelector('[data-tour-step="navegacion-mes"]');
         assert(group.classList.contains('input-group'), 'Controles visibles deben agruparse como input-group');
+        assert(group.classList.contains('input-group-lg'), 'Controles visibles deben usar input-group-lg');
         assert(group.querySelector('.input-group-text .bi-calendar-event') !== null, 'Input group debe incluir icono de calendario');
+        assert(selector.querySelector('#ms-prev').classList.contains('btn-primary'), 'Botón anterior debe usar btn-primary');
+        assert(selector.querySelector('#ms-next').classList.contains('btn-primary'), 'Botón siguiente debe usar btn-primary');
 
         input.value = '2026-07';
         input.dispatchEvent(new Event('change'));

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -181,7 +181,7 @@ export const tests = [
 
         setSelectedMonth('2026-06');
 
-        const monthEl = header.querySelector('#resumen-header-month span');
+        const monthEl = header.querySelector('#resumen-header-month');
         assert(monthEl.textContent === 'Junio de 2026', 'Mes destacado debe reflejar el mes seleccionado con capitalización correcta');
 
         header.destroy();
@@ -199,7 +199,10 @@ export const tests = [
         assert(input.classList.contains('visually-hidden-focusable'), 'Input date debe permanecer oculto visualmente hasta recibir foco');
 
         const group = selector.querySelector('[data-tour-step="navegacion-mes"]');
-        assert(group.classList.contains('btn-group'), 'Controles visibles deben agruparse como btn-group compacto');
+        assert(group.classList.contains('d-inline-flex'), 'Controles visibles deben alinearse con flexbox');
+        assert(!group.classList.contains('btn-group'), 'Controles visibles no deben usar btn-group');
+        assert(selector.querySelector('#ms-prev').classList.contains('rounded-circle'), 'Botón anterior debe ser redondeado');
+        assert(selector.querySelector('#ms-next').classList.contains('rounded-circle'), 'Botón siguiente debe ser redondeado');
 
         input.value = '2026-07-15';
         input.dispatchEvent(new Event('change'));

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -7,7 +7,6 @@ import '../src/layout/PageSectionLayout.js';
 import '../src/layout/Sidebar.js';
 import '../src/layout/BottomNav.js';
 import { navItems, DEFAULT_SUBTITLE } from '../src/layout/navConfig.js';
-import { setSelectedMonth } from '../src/shared/MonthFilter.js';
 import { openSettingsModal } from '../src/layout/dataActions.js';
 import Home from '../src/pages/Home.js';
 import { createIconButton } from '../src/shared/components/createIconButton.js';
@@ -153,8 +152,9 @@ export const tests = [
         assert(subtitleEl !== null, 'ResumenHeader debe tener #resumen-header-subtitle');
         assert(subtitleEl.textContent === 'Gestioná tus pagos y vencimientos del período.', 'Subtítulo debe usar la bajada breve');
 
-        const monthEl = header.querySelector('#resumen-header-month');
-        assert(monthEl !== null, 'ResumenHeader debe destacar el mes seleccionado');
+        const selector = header.querySelector('month-selector');
+        assert(selector !== null, 'ResumenHeader debe mostrar el selector de mes');
+        assert(header.querySelector('#resumen-header-month') === null, 'ResumenHeader no debe duplicar el mes fuera del input');
 
         document.body.removeChild(header);
     },
@@ -174,39 +174,34 @@ export const tests = [
     },
 
 
-    async function resumenHeader_updatesFeaturedMonth() {
-        console.log('  ResumenHeader: updates featured month label when global month changes');
+    async function resumenHeader_doesNotRenderSeparateMonthText() {
+        console.log('  ResumenHeader: does not render separate month text outside selector');
         const header = ResumenHeader();
         document.body.appendChild(header);
 
-        setSelectedMonth('2026-06');
-
         const monthEl = header.querySelector('#resumen-header-month');
-        assert(monthEl.textContent === 'Junio de 2026', 'Mes destacado debe reflejar el mes seleccionado con capitalización correcta');
+        assert(monthEl === null, 'ResumenHeader no debe renderizar texto de mes separado del selector');
 
-        header.destroy();
         document.body.removeChild(header);
     },
 
     async function monthSelector_usesAccessibleDateInput() {
-        console.log('  MonthSelector: uses accessible input[type=date]');
+        console.log('  MonthSelector: uses compact input group with month input');
         const selector = document.createElement('month-selector');
         document.body.appendChild(selector);
 
         const input = selector.querySelector('#ms-input');
-        assert(input.type === 'date', 'Selector debe mantener un input date accesible');
-        assert(input.getAttribute('aria-label') === 'Seleccionar fecha del mes', 'Input date debe tener aria-label');
-        assert(input.classList.contains('visually-hidden-focusable'), 'Input date debe permanecer oculto visualmente hasta recibir foco');
+        assert(input.type === 'month', 'Selector debe usar un input month visible');
+        assert(input.getAttribute('aria-label') === 'Seleccionar mes', 'Input month debe tener aria-label');
+        assert(input.classList.contains('form-control'), 'Input month debe usar form-control');
 
         const group = selector.querySelector('[data-tour-step="navegacion-mes"]');
-        assert(group.classList.contains('d-inline-flex'), 'Controles visibles deben alinearse con flexbox');
-        assert(!group.classList.contains('btn-group'), 'Controles visibles no deben usar btn-group');
-        assert(selector.querySelector('#ms-prev').classList.contains('rounded-circle'), 'Botón anterior debe ser redondeado');
-        assert(selector.querySelector('#ms-next').classList.contains('rounded-circle'), 'Botón siguiente debe ser redondeado');
+        assert(group.classList.contains('input-group'), 'Controles visibles deben agruparse como input-group');
+        assert(group.querySelector('.input-group-text .bi-calendar-event') !== null, 'Input group debe incluir icono de calendario');
 
-        input.value = '2026-07-15';
+        input.value = '2026-07';
         input.dispatchEvent(new Event('change'));
-        assert(selector.querySelector('#ms-input').value === '2026-07-01', 'Selector debe normalizar la fecha al mes seleccionado');
+        assert(selector.querySelector('#ms-input').value === '2026-07', 'Selector debe conservar el mes seleccionado');
 
         document.body.removeChild(selector);
     },

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -182,7 +182,7 @@ export const tests = [
         setSelectedMonth('2026-06');
 
         const monthEl = header.querySelector('#resumen-header-month span');
-        assert(monthEl.textContent === 'junio de 2026', 'Mes destacado debe reflejar el mes seleccionado');
+        assert(monthEl.textContent === 'Junio de 2026', 'Mes destacado debe reflejar el mes seleccionado con capitalización correcta');
 
         header.destroy();
         document.body.removeChild(header);
@@ -197,6 +197,9 @@ export const tests = [
         assert(input.type === 'date', 'Selector debe mantener un input date accesible');
         assert(input.getAttribute('aria-label') === 'Seleccionar fecha del mes', 'Input date debe tener aria-label');
         assert(input.classList.contains('visually-hidden-focusable'), 'Input date debe permanecer oculto visualmente hasta recibir foco');
+
+        const group = selector.querySelector('[data-tour-step="navegacion-mes"]');
+        assert(group.classList.contains('btn-group'), 'Controles visibles deben agruparse como btn-group compacto');
 
         input.value = '2026-07-15';
         input.dispatchEvent(new Event('change'));

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -7,6 +7,7 @@ import '../src/layout/PageSectionLayout.js';
 import '../src/layout/Sidebar.js';
 import '../src/layout/BottomNav.js';
 import { navItems, DEFAULT_SUBTITLE } from '../src/layout/navConfig.js';
+import { setSelectedMonth } from '../src/shared/MonthFilter.js';
 import { openSettingsModal } from '../src/layout/dataActions.js';
 import Home from '../src/pages/Home.js';
 import { createIconButton } from '../src/shared/components/createIconButton.js';
@@ -119,9 +120,9 @@ export const tests = [
     },
 
     async function navConfig_homeTitle() {
-        console.log('  navConfig: Home title is "Panorama financiero"');
+        console.log('  navConfig: Home title is "Tu panorama financiero"');
         const home = navItems.find(i => i.path === '/');
-        assert(home.title === 'Panorama financiero', 'Home debe tener título "Panorama financiero"');
+        assert(home.title === 'Tu panorama financiero', 'Home debe tener título "Tu panorama financiero"');
     },
 
     async function navConfig_gastosTitle() {
@@ -146,11 +147,14 @@ export const tests = [
 
         const titleEl = header.querySelector('#resumen-header-title');
         assert(titleEl !== null, 'ResumenHeader debe tener #resumen-header-title');
-        assert(titleEl.textContent === 'Panorama financiero', 'Título por defecto debe ser "Panorama financiero"');
+        assert(titleEl.textContent === 'Tu panorama financiero', 'Título por defecto debe ser "Tu panorama financiero"');
 
         const subtitleEl = header.querySelector('#resumen-header-subtitle');
         assert(subtitleEl !== null, 'ResumenHeader debe tener #resumen-header-subtitle');
-        assert(subtitleEl.textContent.length > 0, 'Subtítulo no debe estar vacío');
+        assert(subtitleEl.textContent === 'Gestioná tus pagos y vencimientos del período.', 'Subtítulo debe usar la bajada breve');
+
+        const monthEl = header.querySelector('#resumen-header-month');
+        assert(monthEl !== null, 'ResumenHeader debe destacar el mes seleccionado');
 
         document.body.removeChild(header);
     },
@@ -167,6 +171,37 @@ export const tests = [
         assert(subtitleEl.textContent === 'Mi subtítulo personalizado.', 'Debe renderizar el subtítulo personalizado');
 
         document.body.removeChild(header);
+    },
+
+
+    async function resumenHeader_updatesFeaturedMonth() {
+        console.log('  ResumenHeader: updates featured month label when global month changes');
+        const header = ResumenHeader();
+        document.body.appendChild(header);
+
+        setSelectedMonth('2026-06');
+
+        const monthEl = header.querySelector('#resumen-header-month span');
+        assert(monthEl.textContent === 'junio de 2026', 'Mes destacado debe reflejar el mes seleccionado');
+
+        header.destroy();
+        document.body.removeChild(header);
+    },
+
+    async function monthSelector_usesAccessibleDateInput() {
+        console.log('  MonthSelector: uses accessible input[type=date]');
+        const selector = document.createElement('month-selector');
+        document.body.appendChild(selector);
+
+        const input = selector.querySelector('#ms-input');
+        assert(input.type === 'date', 'Selector debe mantener un input date accesible');
+        assert(input.getAttribute('aria-label') === 'Seleccionar fecha del mes', 'Input date debe tener aria-label');
+
+        input.value = '2026-07-15';
+        input.dispatchEvent(new Event('change'));
+        assert(selector.querySelector('#ms-input').value === '2026-07-01', 'Selector debe normalizar la fecha al mes seleccionado');
+
+        document.body.removeChild(selector);
     },
 
     async function resumenHeader_updateChangesTitle() {


### PR DESCRIPTION
### Motivation
- Destacar el mes seleccionado en el encabezado móvil para evitar competencia horizontal entre título y selector y mejorar la legibilidad en pantallas pequeñas.
- Mantener la accesibilidad del control de selección de periodo usando un input nativo y asegurar que el filtro mensual siga funcionando correctamente.
- Actualizar el copy del encabezado y la bajada compartida para reflejar el nuevo diseño y mensaje.

### Description
- Reemplazado `input[type=month]` por un `input[type=date]` en `src/layout/MonthSelector.js`, con normalización a `YYYY-MM` al guardar y sincronización a la forma `${month}-01` para mantener compatibilidad con el filtro mensual.
- Añadido un label destacado del mes con ícono de calendario en `src/layout/ResumenHeader.js`, reorganizado el layout a `d-flex`/`flex-wrap` para mobile, suscripción a `ui:month` para actualizar la etiqueta y método `destroy` para limpiar listeners; la visibilidad del label se sincroniza con `hideMonthSelector`.
- Actualizado el texto compartido en `src/layout/navConfig.js` cambiando el `DEFAULT_SUBTITLE` y el título de la ruta Home a `Tu panorama financiero`.
- Agregadas y ajustadas aserciones en `test/layout.test.js` para cubrir el label del mes destacado y el uso accesible de `input[type=date]`.

### Testing
- Ejecutado `npm test` con resultado `995 passed, 0 failed`.
- Ejecutado `npm run build` y se generó el bundle de producción sin errores.
- Ejecutado `npm run lint` sin reportar advertencias ni errores.
- Intento de tomar screenshot con Playwright falló porque el paquete `playwright` no está disponible en el entorno, por lo que la verificación visual fue omitida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30accf37e883238e13722d9fc9ad86)