### PR TITLE
MonthSelector: fixed mobile controls and accessibility improvements

### DIFF
--- a/src/layout/MonthSelector.js
+++ b/src/layout/MonthSelector.js
@@ -1,5 +1,5 @@
 // src/layout/MonthSelector.js
-// Compact global month selector web component — Bootstrap Input Group with input[type=month]
+// Compact global month selector web component with fixed mobile controls
 import {
     getSelectedMonth,
     setSelectedMonth,
@@ -21,43 +21,54 @@ export class MonthSelector extends HTMLElement {
     }
 
     _render() {
+        const label = document.createElement('label');
+        label.className = 'visually-hidden';
+        label.htmlFor = 'period-selector';
+        label.textContent = 'Período';
+
         const group = document.createElement('div');
-        group.className = 'input-group input-group-lg mb-3';
+        group.className = 'period-selector mb-3';
         group.dataset.tourStep = 'navegacion-mes';
 
         const icon = document.createElement('span');
-        icon.className = 'input-group-text';
+        icon.className = 'period-selector__icon input-group-text';
         icon.innerHTML = '<i class="bi bi-calendar-event" aria-hidden="true"></i>';
+
+        const input = document.createElement('input');
+        input.id = 'period-selector';
+        input.type = 'month';
+        input.className = 'period-selector__input form-control form-control-lg';
+        input.value = getSelectedMonth();
+        input.setAttribute('aria-label', 'Seleccionar período');
+
+        const actions = document.createElement('div');
+        actions.className = 'period-selector__actions';
+        actions.setAttribute('aria-label', 'Navegación de período');
 
         const prev = document.createElement('button');
         prev.id = 'ms-prev';
-        prev.className = 'btn btn-primary';
+        prev.className = 'period-selector__button btn btn-primary';
         prev.type = 'button';
         prev.title = 'Mes anterior';
         prev.setAttribute('aria-label', 'Mes anterior');
         prev.textContent = '‹';
 
-        const input = document.createElement('input');
-        input.id = 'ms-input';
-        input.type = 'month';
-        input.className = 'form-control';
-        input.value = getSelectedMonth();
-        input.setAttribute('aria-label', 'Seleccionar mes');
-
         const next = document.createElement('button');
         next.id = 'ms-next';
-        next.className = 'btn btn-primary';
+        next.className = 'period-selector__button btn btn-primary';
         next.type = 'button';
         next.title = 'Mes siguiente';
         next.setAttribute('aria-label', 'Mes siguiente');
         next.textContent = '›';
 
+        actions.appendChild(prev);
+        actions.appendChild(next);
         group.appendChild(icon);
-        group.appendChild(prev);
-        group.appendChild(next);
         group.appendChild(input);
+        group.appendChild(actions);
 
         this.innerHTML = '';
+        this.appendChild(label);
         this.appendChild(group);
         this.querySelector('#ms-prev').addEventListener('click', () => {
             goToPreviousMonth();
@@ -73,7 +84,7 @@ export class MonthSelector extends HTMLElement {
                 month: getSelectedMonth()
             });
         });
-        this.querySelector('#ms-input').addEventListener('change', (e) => {
+        this.querySelector('#period-selector').addEventListener('change', (e) => {
             if (e.target.value) {
                 setSelectedMonth(e.target.value);
                 trackEvent('monthly_navigation_used', {
@@ -85,7 +96,7 @@ export class MonthSelector extends HTMLElement {
     }
 
     _syncInput(month) {
-        const input = this.querySelector('#ms-input');
+        const input = this.querySelector('#period-selector');
         if (input && input.value !== month) input.value = month;
     }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -75,3 +75,48 @@ app-sidebar {
     top: 0;
     overflow-y: auto;
 }
+
+// Fixed period selector layout: calendar | centered month input | grouped arrows.
+// Keeps navigation reachable on mobile even with long localized month names.
+.period-selector {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: stretch;
+    width: min(100%, 26rem);
+}
+
+.period-selector__icon,
+.period-selector__button {
+    min-width: 44px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.period-selector__icon {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.period-selector__input {
+    min-width: 0;
+    text-align: center;
+    border-radius: 0;
+}
+
+.period-selector__actions {
+    display: inline-flex;
+}
+
+.period-selector__button {
+    border-radius: 0;
+    font-size: 1.5rem;
+    line-height: 1;
+    padding-inline: 0.75rem;
+}
+
+.period-selector__button + .period-selector__button {
+    border-top-right-radius: var(--bs-border-radius-lg);
+    border-bottom-right-radius: var(--bs-border-radius-lg);
+}

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -186,25 +186,38 @@ export const tests = [
     },
 
     async function monthSelector_usesAccessibleDateInput() {
-        console.log('  MonthSelector: uses compact input group with month input');
+        console.log('  MonthSelector: uses fixed period selector with month input');
         const selector = document.createElement('month-selector');
         document.body.appendChild(selector);
 
-        const input = selector.querySelector('#ms-input');
+        const label = selector.querySelector('label[for="period-selector"]');
+        assert(label !== null, 'Selector debe asociar un label al input de período');
+        assert(label.textContent === 'Período', 'Label debe describir el período');
+
+        const input = selector.querySelector('#period-selector');
         assert(input.type === 'month', 'Selector debe usar un input month visible');
-        assert(input.getAttribute('aria-label') === 'Seleccionar mes', 'Input month debe tener aria-label');
+        assert(input.getAttribute('aria-label') === 'Seleccionar período', 'Input month debe tener aria-label');
         assert(input.classList.contains('form-control'), 'Input month debe usar form-control');
+        assert(input.classList.contains('period-selector__input'), 'Input debe usar clase del layout centrado');
 
         const group = selector.querySelector('[data-tour-step="navegacion-mes"]');
-        assert(group.classList.contains('input-group'), 'Controles visibles deben agruparse como input-group');
-        assert(group.classList.contains('input-group-lg'), 'Controles visibles deben usar input-group-lg');
-        assert(group.querySelector('.input-group-text .bi-calendar-event') !== null, 'Input group debe incluir icono de calendario');
+        assert(group.classList.contains('period-selector'), 'Controles visibles deben usar layout fijo de período');
+        assert(group.children[0].classList.contains('period-selector__icon'), 'Icono debe quedar primero');
+        assert(group.children[1] === input, 'Input debe quedar centrado entre icono y flechas');
+        assert(group.querySelector('.period-selector__icon .bi-calendar-event') !== null, 'Selector debe incluir icono de calendario');
+
+        const actions = group.querySelector('.period-selector__actions');
+        assert(actions !== null, 'Flechas deben estar agrupadas en un contenedor de acciones');
+        assert(actions.children[0].id === 'ms-prev', 'Botón anterior debe ser la primera flecha agrupada');
+        assert(actions.children[1].id === 'ms-next', 'Botón siguiente debe ser la segunda flecha agrupada');
+        assert(selector.querySelector('#ms-prev').classList.contains('period-selector__button'), 'Botón anterior debe usar clase táctil');
+        assert(selector.querySelector('#ms-next').classList.contains('period-selector__button'), 'Botón siguiente debe usar clase táctil');
         assert(selector.querySelector('#ms-prev').classList.contains('btn-primary'), 'Botón anterior debe usar btn-primary');
         assert(selector.querySelector('#ms-next').classList.contains('btn-primary'), 'Botón siguiente debe usar btn-primary');
 
         input.value = '2026-07';
         input.dispatchEvent(new Event('change'));
-        assert(selector.querySelector('#ms-input').value === '2026-07', 'Selector debe conservar el mes seleccionado');
+        assert(selector.querySelector('#period-selector').value === '2026-07', 'Selector debe conservar el mes seleccionado');
 
         document.body.removeChild(selector);
     },


### PR DESCRIPTION
### Motivation

- Make the compact month selector more usable on small screens by ensuring navigation buttons remain reachable even with long localized month names and improve accessibility by adding an associated label.

### Description

- Replace the previous Bootstrap input-group structure with a fixed `.period-selector` grid layout and introduce a visually hidden `<label>` associated with the month input (`id="period-selector"`).
- Rework DOM structure inside `MonthSelector` to use `period-selector__icon`, `period-selector__input`, `period-selector__actions` and `period-selector__button` classes and group the previous/next buttons inside an actions container while keeping event handlers and tracking calls.
- Add CSS rules in `src/styles/main.scss` to enforce the three-column layout, center the month input, and provide touch-friendly sizing for the icon and arrow buttons.
- Update `test/layout.test.js` to reflect the new markup and accessibility changes by checking for the label, new IDs/classes, icon placement, grouped actions and preserved input behavior.

### Testing

- Ran the automated test suite with `npm test` which executed the updated `test/layout.test.js` assertions and related layout tests, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3488f6615c83238fa27f6114cf0c64)